### PR TITLE
feat: set up layered architecture with domain

### DIFF
--- a/src/main/java/com/aac/backend/BackendApplication.java
+++ b/src/main/java/com/aac/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.aac.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/aac/backend/controller/CategoryController.java
+++ b/src/main/java/com/aac/backend/controller/CategoryController.java
@@ -1,0 +1,29 @@
+package com.aac.backend.controller;
+
+import com.aac.backend.controller.dto.response.CategoryResponse;
+import com.aac.backend.domain.Category;
+import com.aac.backend.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponse>> getCategories() {
+        List<Category> categories = categoryService.getCategories();
+
+        return ResponseEntity.ok(categories.stream()
+                .map(CategoryResponse::from)
+                .toList());
+    }
+}

--- a/src/main/java/com/aac/backend/controller/UserController.java
+++ b/src/main/java/com/aac/backend/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.aac.backend.controller;
+
+import com.aac.backend.controller.dto.response.UserResponse;
+import com.aac.backend.domain.User;
+import com.aac.backend.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    // TODO: JWT 인증 구현 후 SecurityContext에서 userId 추출
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getMe(@RequestHeader("X-User-Id") Long userId) {
+        User user = userService.getUser(userId);
+
+        return ResponseEntity.ok(UserResponse.from(user));
+    }
+}

--- a/src/main/java/com/aac/backend/controller/WordController.java
+++ b/src/main/java/com/aac/backend/controller/WordController.java
@@ -1,0 +1,37 @@
+package com.aac.backend.controller;
+
+import com.aac.backend.controller.dto.request.SentenceRequest;
+import com.aac.backend.controller.dto.response.SentenceResponse;
+import com.aac.backend.controller.dto.response.WordResponse;
+import com.aac.backend.domain.Word;
+import com.aac.backend.service.WordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/words")
+public class WordController {
+
+    private final WordService wordService;
+
+    @GetMapping
+    public ResponseEntity<List<WordResponse>> getWords(@RequestParam String category) {
+        List<Word> words = wordService.getWords(category);
+
+        return ResponseEntity.ok(words.stream()
+                .map(WordResponse::from)
+                .toList());
+    }
+
+    @PostMapping("/sentence")
+    public ResponseEntity<SentenceResponse> generateSentence(@Valid @RequestBody SentenceRequest request) {
+        String sentence = wordService.generateSentence(request);
+
+        return ResponseEntity.ok(new SentenceResponse(sentence));
+    }
+}

--- a/src/main/java/com/aac/backend/controller/dto/request/SentenceRequest.java
+++ b/src/main/java/com/aac/backend/controller/dto/request/SentenceRequest.java
@@ -1,0 +1,9 @@
+package com.aac.backend.controller.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record SentenceRequest(
+        @NotEmpty List<Long> wordIds
+) {}

--- a/src/main/java/com/aac/backend/controller/dto/response/CategoryResponse.java
+++ b/src/main/java/com/aac/backend/controller/dto/response/CategoryResponse.java
@@ -1,0 +1,17 @@
+package com.aac.backend.controller.dto.response;
+
+import com.aac.backend.domain.Category;
+
+public record CategoryResponse(
+        Long id,
+        String name,
+        String label
+) {
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getLabel()
+        );
+    }
+}

--- a/src/main/java/com/aac/backend/controller/dto/response/SentenceResponse.java
+++ b/src/main/java/com/aac/backend/controller/dto/response/SentenceResponse.java
@@ -1,0 +1,3 @@
+package com.aac.backend.controller.dto.response;
+
+public record SentenceResponse(String sentence) {}

--- a/src/main/java/com/aac/backend/controller/dto/response/UserResponse.java
+++ b/src/main/java/com/aac/backend/controller/dto/response/UserResponse.java
@@ -1,0 +1,21 @@
+package com.aac.backend.controller.dto.response;
+
+import com.aac.backend.domain.User;
+
+import java.time.LocalDateTime;
+
+public record UserResponse(
+        Long id,
+        String email,
+        String name,
+        LocalDateTime createdAt
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/aac/backend/controller/dto/response/WordResponse.java
+++ b/src/main/java/com/aac/backend/controller/dto/response/WordResponse.java
@@ -1,0 +1,19 @@
+package com.aac.backend.controller.dto.response;
+
+import com.aac.backend.domain.Word;
+
+public record WordResponse(
+        Long id,
+        String label,
+        String imageUrl,
+        String category
+) {
+    public static WordResponse from(Word word) {
+        return new WordResponse(
+                word.getId(),
+                word.getLabel(),
+                word.getImageUrl(),
+                word.getCategory().getName()
+        );
+    }
+}

--- a/src/main/java/com/aac/backend/domain/BaseEntity.java
+++ b/src/main/java/com/aac/backend/domain/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.aac.backend.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/aac/backend/domain/Category.java
+++ b/src/main/java/com/aac/backend/domain/Category.java
@@ -1,0 +1,32 @@
+package com.aac.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "category")
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private String label;
+
+    private Category(String name, String label) {
+        this.name = name;
+        this.label = label;
+    }
+
+    public static Category create(String name, String label) {
+        return new Category(name, label);
+    }
+}

--- a/src/main/java/com/aac/backend/domain/CategoryRepository.java
+++ b/src/main/java/com/aac/backend/domain/CategoryRepository.java
@@ -1,0 +1,6 @@
+package com.aac.backend.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/aac/backend/domain/User.java
+++ b/src/main/java/com/aac/backend/domain/User.java
@@ -1,0 +1,32 @@
+package com.aac.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    private User(String email, String name) {
+        this.email = email;
+        this.name = name;
+    }
+
+    public static User create(String email, String name) {
+        return new User(email, name);
+    }
+}

--- a/src/main/java/com/aac/backend/domain/UserRepository.java
+++ b/src/main/java/com/aac/backend/domain/UserRepository.java
@@ -1,0 +1,6 @@
+package com.aac.backend.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/aac/backend/domain/Word.java
+++ b/src/main/java/com/aac/backend/domain/Word.java
@@ -1,0 +1,36 @@
+package com.aac.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "word")
+public class Word extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String label;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    private Word(String label, String imageUrl, Category category) {
+        this.label = label;
+        this.imageUrl = imageUrl;
+        this.category = category;
+    }
+
+    public static Word create(String label, String imageUrl, Category category) {
+        return new Word(label, imageUrl, category);
+    }
+}

--- a/src/main/java/com/aac/backend/domain/WordRepository.java
+++ b/src/main/java/com/aac/backend/domain/WordRepository.java
@@ -1,0 +1,10 @@
+package com.aac.backend.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WordRepository extends JpaRepository<Word, Long> {
+
+    List<Word> findByCategory_Name(String categoryName);
+}

--- a/src/main/java/com/aac/backend/global/exception/BusinessException.java
+++ b/src/main/java/com/aac/backend/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.aac.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/aac/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/aac/backend/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.aac.backend.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
+    WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "WORD_NOT_FOUND", "단어를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "카테고리를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/aac/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/aac/backend/global/exception/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.aac.backend.global.exception;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        LocalDateTime timestamp
+) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/aac/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aac/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.aac.backend.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity.internalServerError().body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/aac/backend/service/CategoryService.java
+++ b/src/main/java/com/aac/backend/service/CategoryService.java
@@ -1,0 +1,20 @@
+package com.aac.backend.service;
+
+import com.aac.backend.domain.Category;
+import com.aac.backend.domain.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public List<Category> getCategories() {
+        return categoryRepository.findAll();
+    }
+}

--- a/src/main/java/com/aac/backend/service/UserService.java
+++ b/src/main/java/com/aac/backend/service/UserService.java
@@ -1,0 +1,21 @@
+package com.aac.backend.service;
+
+import com.aac.backend.domain.User;
+import com.aac.backend.domain.UserRepository;
+import com.aac.backend.global.exception.BusinessException;
+import com.aac.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User getUser(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/aac/backend/service/WordService.java
+++ b/src/main/java/com/aac/backend/service/WordService.java
@@ -1,0 +1,32 @@
+package com.aac.backend.service;
+
+import com.aac.backend.domain.Word;
+import com.aac.backend.domain.WordRepository;
+import com.aac.backend.controller.dto.request.SentenceRequest;
+import com.aac.backend.global.exception.BusinessException;
+import com.aac.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WordService {
+
+    private final WordRepository wordRepository;
+
+    public List<Word> getWords(String categoryName) {
+        return wordRepository.findByCategory_Name(categoryName);
+    }
+
+    public String generateSentence(SentenceRequest request) {
+        return request.wordIds().stream()
+                .map(id -> wordRepository.findById(id)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.WORD_NOT_FOUND)))
+                .map(Word::getLabel)
+                .reduce((a, b) -> a + " " + b)
+                .orElse("");
+    }
+}


### PR DESCRIPTION
## Summary
- Add User, Category, Word entities with BaseEntity (createdAt auditing)
- Add service layer returning domain objects
- Add controller layer handling DTO conversion
- Add global exception handling with ErrorCode and ErrorResponse

## Note
- Auth (Google OAuth, JWT) is not implemented yet
- Sentence generation is a stub (label concatenation)