### PR TITLE
chore: separate application yml for local and prod environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
-
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/aac/backend/presentation/config/CorsProperties.java
+++ b/src/main/java/com/aac/backend/presentation/config/CorsProperties.java
@@ -1,0 +1,10 @@
+package com.aac.backend.presentation.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "cors")
+public record CorsProperties(List<String> allowedOrigins) {
+
+}

--- a/src/main/java/com/aac/backend/presentation/config/WebConfig.java
+++ b/src/main/java/com/aac/backend/presentation/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.aac.backend.presentation.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableConfigurationProperties(CorsProperties.class)
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CorsProperties corsProperties;
+
+    public WebConfig(CorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new))
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:aac
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+      dialect: org.hibernate.dialect.H2Dialect
+    show-sql: true
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,13 +1,8 @@
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/aac
-    username: root
-    password: root
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
+  application:
+    name: aac-backend
+  profiles:
+    active: local
   ai:
     openai:
       api-key: ${OPENAI_API_KEY}
@@ -18,3 +13,7 @@ spring:
       embedding:
         options:
           model: text-embedding-3-small
+cors:
+  allowed-origins:
+    - http://localhost:5173
+    - http://127.0.0.1:5173


### PR DESCRIPTION
## 개요
환경별 yml 파일을 분리하고 CORS 설정을 추가합니다.

## 변경 사항
- application.yml: 공통 설정 (profile 기본값, Spring AI)
- application-local.yml: H2 in-memory DB, CORS local origin
- application-prod.yml: MySQL, CORS prod origin (환경변수 기반)
- CorsProperties: yml 바인딩용 record
- WebConfig: CORS 매핑 적용