### PR TITLE
feat: 이전 대화 컨텍스트 유지 기능 추가

### DIFF
--- a/src/main/java/com/aac/backend/domain/ConversationMessage.java
+++ b/src/main/java/com/aac/backend/domain/ConversationMessage.java
@@ -1,0 +1,37 @@
+package com.aac.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "conversation_messages")
+public class ConversationMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String userInput;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String aiResponse;
+
+    private ConversationMessage(User user, String userInput, String aiResponse) {
+        this.user = user;
+        this.userInput = userInput;
+        this.aiResponse = aiResponse;
+    }
+
+    public static ConversationMessage create(User user, String userInput, String aiResponse) {
+        return new ConversationMessage(user, userInput, aiResponse);
+    }
+}

--- a/src/main/java/com/aac/backend/domain/ConversationMessageRepository.java
+++ b/src/main/java/com/aac/backend/domain/ConversationMessageRepository.java
@@ -1,0 +1,10 @@
+package com.aac.backend.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConversationMessageRepository extends JpaRepository<ConversationMessage, Long> {
+
+    List<ConversationMessage> findTop10ByUserIdOrderByCreatedAtAsc(Long userId);
+}

--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -1,11 +1,16 @@
 package com.aac.backend.infra;
 
+import com.aac.backend.domain.ConversationMessage;
 import com.aac.backend.presentation.dto.request.WordRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,15 +21,22 @@ public class WordSentenceGenerator {
 
     private final ChatClient chatClient;
 
-    public String generate(List<WordRequest> wordRequests) {
+    public String generate(List<WordRequest> wordRequests, List<ConversationMessage> history) {
         var symbols = formatWords(wordRequests);
         log.info("symbols: {}", symbols);
+
+        List<Message> messages = new ArrayList<>();
+        for (ConversationMessage msg : history) {
+            messages.add(new UserMessage(msg.getUserInput()));
+            messages.add(new AssistantMessage(msg.getAiResponse()));
+        }
 
         var response = chatClient.prompt()
                 .system("""
                         당신은 발달장애인의 의사소통을 돕는 AAC 시스템입니다.
                         사용자가 선택한 기호 목록을 자연스러운 한국어 문장 1개로 변환하세요.
-                        
+                        이전 대화 내용이 있다면 맥락을 반영하세요.
+
                         규칙:
                         - 입력된 기호를 모두 포함해야 합니다.
                         - 기호를 임의로 추가하거나 생략하지 마세요.
@@ -32,17 +44,18 @@ public class WordSentenceGenerator {
                         - 문장은 1인칭 기준으로 작성하세요.
                         - 간결하고 자연스러운 구어체로 작성하세요.
                         - 문장만 출력하세요.
-                        
+
                         예시:
                         입력: [감정] 배고파, [음식] 밥, [행동] 먹고싶어
                         출력: 나 배고파, 밥 먹고 싶어.
-                        
+
                         입력: [장소] 학교, [행동] 가고싶어
                         출력: 나 학교 가고 싶어.
-                        
+
                         입력: [음식] 물, [행동] 먹고싶어
                         출력: 나 물 마시고 싶어.
                         """)
+                .messages(messages)
                 .user(symbols)
                 .call()
                 .chatResponse();
@@ -56,7 +69,7 @@ public class WordSentenceGenerator {
         return response.getResult().getOutput().getText();
     }
 
-    private String formatWords(List<WordRequest> words) {
+    public String formatWords(List<WordRequest> words) {
         return words.stream()
                 .map(w -> "[" + w.category() + "] " + w.label())
                 .collect(Collectors.joining(", "));

--- a/src/main/java/com/aac/backend/presentation/WordController.java
+++ b/src/main/java/com/aac/backend/presentation/WordController.java
@@ -1,26 +1,23 @@
 package com.aac.backend.presentation;
 
-import com.aac.backend.infra.WordSentenceGenerator;
 import com.aac.backend.presentation.dto.request.SentenceRequest;
 import com.aac.backend.presentation.dto.response.SentenceResponse;
+import com.aac.backend.service.WordService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/words")
 public class WordController {
 
-    private final WordSentenceGenerator wordSentenceGenerator;
+    private final WordService wordService;
 
     @PostMapping("/sentence")
     public ResponseEntity<SentenceResponse> generateSentence(@Valid @RequestBody SentenceRequest request) {
-        var sentence = wordSentenceGenerator.generate(request.words());
-
+        var sentence = wordService.generateSentence(request.words());
         return ResponseEntity.ok(new SentenceResponse(sentence));
     }
 }

--- a/src/main/java/com/aac/backend/service/WordService.java
+++ b/src/main/java/com/aac/backend/service/WordService.java
@@ -1,0 +1,41 @@
+package com.aac.backend.service;
+
+import com.aac.backend.domain.ConversationMessage;
+import com.aac.backend.domain.ConversationMessageRepository;
+import com.aac.backend.domain.User;
+import com.aac.backend.domain.UserRepository;
+import com.aac.backend.global.exception.BusinessException;
+import com.aac.backend.global.exception.ErrorCode;
+import com.aac.backend.infra.WordSentenceGenerator;
+import com.aac.backend.presentation.dto.request.WordRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WordService {
+
+    private static final Long FIXED_USER_ID = 1L;
+
+    private final WordSentenceGenerator wordSentenceGenerator;
+    private final ConversationMessageRepository conversationMessageRepository;
+    private final UserRepository userRepository;
+
+    public String generateSentence(List<WordRequest> words) {
+        User user = userRepository.findById(FIXED_USER_ID)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        List<ConversationMessage> history =
+                conversationMessageRepository.findTop10ByUserIdOrderByCreatedAtAsc(FIXED_USER_ID);
+
+        String sentence = wordSentenceGenerator.generate(words, history);
+
+        String userInput = wordSentenceGenerator.formatWords(words);
+        conversationMessageRepository.save(ConversationMessage.create(user, userInput, sentence));
+
+        return sentence;
+    }
+}


### PR DESCRIPTION
## 작업 내용
- `ConversationMessage` 엔티티 추가 (user, userInput, aiResponse)
- `ConversationMessageRepository` 추가 (유저별 최근 10개 히스토리 조회)
- `WordSentenceGenerator` 수정 — 히스토리를 Spring AI messages()로 전달
- `WordService` 추가 — userId=1 고정, 히스토리 조회 → AI 호출 → 저장
- `WordController` 수정 — WordService로 위임

## 변경 이유
AI 문장 생성 시 이전 대화 맥락을 반영하여 자연스러운 응답 생성

Closes #4