### PR TITLE
feat: implement Google OAuth login

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/resources/config"]
+	path = src/main/resources/config
+	url = https://github.com/AAC-ai/backend-config.git

--- a/src/main/java/com/aac/backend/domain/User.java
+++ b/src/main/java/com/aac/backend/domain/User.java
@@ -21,12 +21,15 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    private User(String email, String name) {
+    private String profileImageUrl;
+
+    private User(String email, String name, String profileImageUrl) {
         this.email = email;
         this.name = name;
+        this.profileImageUrl = profileImageUrl;
     }
 
-    public static User create(String email, String name) {
-        return new User(email, name);
+    public static User create(String email, String name, String profileImageUrl) {
+        return new User(email, name, profileImageUrl);
     }
 }

--- a/src/main/java/com/aac/backend/domain/UserRepository.java
+++ b/src/main/java/com/aac/backend/domain/UserRepository.java
@@ -2,5 +2,9 @@ package com.aac.backend.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthClient.java
+++ b/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthClient.java
@@ -35,14 +35,6 @@ public class GoogleOAuthClient {
         this.restClient = restClientBuilder.requestFactory(factory).build();
     }
 
-    public String getAuthorizationUrl() {
-        return properties.getAuthUri()
-                + "?client_id=" + properties.getClientId()
-                + "&redirect_uri=" + properties.getRedirectUri()
-                + "&response_type=code"
-                + "&scope=email%20profile";
-    }
-
     public GoogleUserInfoResponse getUserInfo(final String code) {
         String accessToken = requestAccessToken(code);
         return requestUserInfo(accessToken);

--- a/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthClient.java
+++ b/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthClient.java
@@ -1,0 +1,79 @@
+package com.aac.backend.infra.oauth;
+
+import com.aac.backend.global.exception.BusinessException;
+import com.aac.backend.global.exception.ErrorCode;
+import com.aac.backend.infra.oauth.dto.GoogleAccessTokenResponse;
+import com.aac.backend.infra.oauth.dto.GoogleUserInfoResponse;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.util.Objects;
+
+@Component
+@EnableConfigurationProperties(GoogleOAuthProperties.class)
+public class GoogleOAuthClient {
+
+    private static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
+
+    private final GoogleOAuthProperties properties;
+    private final RestClient restClient;
+
+    public GoogleOAuthClient(
+            final GoogleOAuthProperties properties,
+            final RestClient.Builder restClientBuilder
+    ) {
+        this.properties = properties;
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getConnectTimeout());
+        factory.setReadTimeout(properties.getReadTimeout());
+        this.restClient = restClientBuilder.requestFactory(factory).build();
+    }
+
+    public String getAuthorizationUrl() {
+        return properties.getAuthUri()
+                + "?client_id=" + properties.getClientId()
+                + "&redirect_uri=" + properties.getRedirectUri()
+                + "&response_type=code"
+                + "&scope=email%20profile";
+    }
+
+    public GoogleUserInfoResponse getUserInfo(final String code) {
+        String accessToken = requestAccessToken(code);
+        return requestUserInfo(accessToken);
+    }
+
+    private String requestAccessToken(final String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", properties.getClientId());
+        params.add("client_secret", properties.getClientSecret());
+        params.add("redirect_uri", properties.getRedirectUri());
+        params.add("grant_type", GRANT_TYPE_AUTHORIZATION_CODE);
+
+        try {
+            GoogleAccessTokenResponse response = restClient.post()
+                    .uri(properties.getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(GoogleAccessTokenResponse.class);
+            return Objects.requireNonNull(response).accessToken();
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    private GoogleUserInfoResponse requestUserInfo(final String accessToken) {
+        return restClient.get()
+                .uri(properties.getUserUri())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .body(GoogleUserInfoResponse.class);
+    }
+}

--- a/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
+++ b/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
@@ -1,0 +1,38 @@
+package com.aac.backend.infra.oauth;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.google")
+@Getter
+public class GoogleOAuthProperties {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String authUri;
+    private final String tokenUri;
+    private final String userUri;
+    private final String redirectUri;
+    private final int connectTimeout;
+    private final int readTimeout;
+
+    public GoogleOAuthProperties(
+            final String clientId,
+            final String clientSecret,
+            final String authUri,
+            final String tokenUri,
+            final String userUri,
+            final String redirectUri,
+            final int connectTimeout,
+            final int readTimeout
+    ) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.authUri = authUri;
+        this.tokenUri = tokenUri;
+        this.userUri = userUri;
+        this.redirectUri = redirectUri;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+    }
+}

--- a/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
+++ b/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
@@ -9,7 +9,6 @@ public class GoogleOAuthProperties {
 
     private final String clientId;
     private final String clientSecret;
-    private final String authUri;
     private final String tokenUri;
     private final String userUri;
     private final String redirectUri;
@@ -19,7 +18,6 @@ public class GoogleOAuthProperties {
     public GoogleOAuthProperties(
             final String clientId,
             final String clientSecret,
-            final String authUri,
             final String tokenUri,
             final String userUri,
             final String redirectUri,
@@ -28,7 +26,6 @@ public class GoogleOAuthProperties {
     ) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.authUri = authUri;
         this.tokenUri = tokenUri;
         this.userUri = userUri;
         this.redirectUri = redirectUri;

--- a/src/main/java/com/aac/backend/infra/oauth/dto/GoogleAccessTokenResponse.java
+++ b/src/main/java/com/aac/backend/infra/oauth/dto/GoogleAccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.aac.backend.infra.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleAccessTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") Integer expiresIn,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("scope") String scope
+) {}

--- a/src/main/java/com/aac/backend/infra/oauth/dto/GoogleUserInfoResponse.java
+++ b/src/main/java/com/aac/backend/infra/oauth/dto/GoogleUserInfoResponse.java
@@ -1,0 +1,7 @@
+package com.aac.backend.infra.oauth.dto;
+
+public record GoogleUserInfoResponse(
+        String email,
+        String name,
+        String picture
+) {}

--- a/src/main/java/com/aac/backend/presentation/AuthController.java
+++ b/src/main/java/com/aac/backend/presentation/AuthController.java
@@ -15,8 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")

--- a/src/main/java/com/aac/backend/presentation/AuthController.java
+++ b/src/main/java/com/aac/backend/presentation/AuthController.java
@@ -4,13 +4,18 @@ import com.aac.backend.presentation.dto.request.ReissueRequest;
 import com.aac.backend.presentation.dto.response.ApiResponse;
 import com.aac.backend.presentation.dto.response.TokenResponse;
 import com.aac.backend.service.AuthService;
+import com.aac.backend.service.GoogleAuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,10 +23,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final GoogleAuthService googleAuthService;
 
-    @PostMapping("/reissue")
+    @GetMapping("/google")
+    public ResponseEntity<Void> googleLogin() {
+        return ResponseEntity.status(302)
+                .location(URI.create(googleAuthService.getAuthorizationUrl()))
+                .build();
+    }
+
+    @GetMapping("/google/callback")
+    public ResponseEntity<ApiResponse<TokenResponse>> googleCallback(@RequestParam String code) {
+        var tokens = googleAuthService.login(code);
+        return ResponseEntity.ok(ApiResponse.success(tokens));
+    }
+
+    @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> reissue(@Valid @RequestBody ReissueRequest request) {
         var tokens = authService.reissue(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.success(tokens));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@Valid @RequestBody ReissueRequest request) {
+        authService.logout(request.refreshToken());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/aac/backend/service/AuthService.java
+++ b/src/main/java/com/aac/backend/service/AuthService.java
@@ -42,6 +42,12 @@ public class AuthService {
         return new TokenResponse(accessToken, refreshToken);
     }
 
+    @Transactional
+    public void logout(String refreshTokenValue) {
+        refreshTokenRepository.findByToken(refreshTokenValue)
+                .ifPresent(refreshTokenRepository::delete);
+    }
+
     private String issueAndSaveRefreshToken(Long userId) {
         var token = jwtProvider.issueRefreshToken();
         var expiresAt = jwtProvider.refreshExpiresAt();

--- a/src/main/java/com/aac/backend/service/GoogleAuthService.java
+++ b/src/main/java/com/aac/backend/service/GoogleAuthService.java
@@ -1,0 +1,32 @@
+package com.aac.backend.service;
+
+import com.aac.backend.domain.User;
+import com.aac.backend.domain.UserRepository;
+import com.aac.backend.infra.oauth.GoogleOAuthClient;
+import com.aac.backend.presentation.dto.response.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleAuthService {
+
+    private final GoogleOAuthClient googleOAuthClient;
+    private final UserRepository userRepository;
+    private final AuthService authService;
+
+    public String getAuthorizationUrl() {
+        return googleOAuthClient.getAuthorizationUrl();
+    }
+
+    @Transactional
+    public TokenResponse login(String code) {
+        var userInfo = googleOAuthClient.getUserInfo(code);
+        var user = userRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> userRepository.save(
+                        User.create(userInfo.email(), userInfo.name(), userInfo.picture())
+                ));
+        return authService.issueTokens(user.getId());
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,3 +22,14 @@ jwt:
   secret: ${JWT_SECRET}
   expiration-ms: 3600000
   refresh-expiration-ms: 1209600000
+
+oauth:
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    auth-uri: https://accounts.google.com/o/oauth2/auth
+    token-uri: https://oauth2.googleapis.com/token
+    user-uri: https://www.googleapis.com/oauth2/v2/userinfo
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+    connect-timeout: 5000
+    read-timeout: 5000

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,10 @@ spring:
     name: aac-backend
   profiles:
     active: local
+  config:
+    import:
+      - config/jwt.yml
+      - config/oidc.yml
   ai:
     openai:
       api-key: ${OPENAI_API_KEY}
@@ -17,19 +21,3 @@ cors:
   allowed-origins:
     - http://localhost:5173
     - http://127.0.0.1:5173
-
-jwt:
-  secret: ${JWT_SECRET}
-  expiration-ms: 3600000
-  refresh-expiration-ms: 1209600000
-
-oauth:
-  google:
-    client-id: ${GOOGLE_CLIENT_ID}
-    client-secret: ${GOOGLE_CLIENT_SECRET}
-    auth-uri: https://accounts.google.com/o/oauth2/auth
-    token-uri: https://oauth2.googleapis.com/token
-    user-uri: https://www.googleapis.com/oauth2/v2/userinfo
-    redirect-uri: ${GOOGLE_REDIRECT_URI}
-    connect-timeout: 5000
-    read-timeout: 5000


### PR DESCRIPTION
## 작업 내용
- Google OAuth 인가 코드 → 액세스 토큰 → 유저 정보 조회 (`GoogleOAuthClient`)
- 신규 유저 자동 가입 처리 (`GoogleAuthService`)
- `GET /api/auth/google` → Google 로그인 페이지로 302 redirect
- `GET /api/auth/google/callback?code=...` → JWT 토큰 발급
- `POST /api/auth/logout` → 리프레시 토큰 삭제
- `User`에 `profileImageUrl` 필드 추가

## 변경 이유
API 명세서에 정의된 Google OAuth 로그인 흐름 구현

Closes #8