### PR TITLE
chore: set up backend-config submodule for secret management

### DIFF
--- a/src/main/java/com/aac/backend/domain/User.java
+++ b/src/main/java/com/aac/backend/domain/User.java
@@ -21,15 +21,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    private String profileImageUrl;
-
-    private User(String email, String name, String profileImageUrl) {
+    private User(String email, String name) {
         this.email = email;
         this.name = name;
-        this.profileImageUrl = profileImageUrl;
     }
 
-    public static User create(String email, String name, String profileImageUrl) {
-        return new User(email, name, profileImageUrl);
+    public static User create(String email, String name) {
+        return new User(email, name);
     }
 }

--- a/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
+++ b/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
@@ -3,7 +3,7 @@ package com.aac.backend.infra.oauth;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "oauth.google")
+@ConfigurationProperties(prefix = "oidc.google")
 @Getter
 public class GoogleOAuthProperties {
 

--- a/src/main/java/com/aac/backend/infra/oauth/dto/GoogleUserInfoResponse.java
+++ b/src/main/java/com/aac/backend/infra/oauth/dto/GoogleUserInfoResponse.java
@@ -2,6 +2,5 @@ package com.aac.backend.infra.oauth.dto;
 
 public record GoogleUserInfoResponse(
         String email,
-        String name,
-        String picture
+        String name
 ) {}

--- a/src/main/java/com/aac/backend/presentation/AuthController.java
+++ b/src/main/java/com/aac/backend/presentation/AuthController.java
@@ -23,13 +23,6 @@ public class AuthController {
     private final AuthService authService;
     private final GoogleAuthService googleAuthService;
 
-    @GetMapping("/google")
-    public ResponseEntity<Void> googleLogin() {
-        return ResponseEntity.status(302)
-                .location(URI.create(googleAuthService.getAuthorizationUrl()))
-                .build();
-    }
-
     @GetMapping("/google/callback")
     public ResponseEntity<ApiResponse<TokenResponse>> googleCallback(@RequestParam String code) {
         var tokens = googleAuthService.login(code);

--- a/src/main/java/com/aac/backend/service/GoogleAuthService.java
+++ b/src/main/java/com/aac/backend/service/GoogleAuthService.java
@@ -16,16 +16,12 @@ public class GoogleAuthService {
     private final UserRepository userRepository;
     private final AuthService authService;
 
-    public String getAuthorizationUrl() {
-        return googleOAuthClient.getAuthorizationUrl();
-    }
-
     @Transactional
     public TokenResponse login(String code) {
         var userInfo = googleOAuthClient.getUserInfo(code);
         var user = userRepository.findByEmail(userInfo.email())
                 .orElseGet(() -> userRepository.save(
-                        User.create(userInfo.email(), userInfo.name(), userInfo.picture())
+                        User.create(userInfo.email(), userInfo.name())
                 ));
         return authService.issueTokens(user.getId());
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,9 +7,9 @@ spring:
     import:
       - config/jwt.yml
       - config/oidc.yml
+      - config/openai.yml
   ai:
     openai:
-      api-key: ${OPENAI_API_KEY}
       chat:
         options:
           model: gpt-4o


### PR DESCRIPTION
## 작업 내용
- `backend-config` private 레포를 서브모듈로 등록 (`src/main/resources/config/`)
- `application.yaml`에서 `config/jwt.yml`, `config/oidc.yml`, `config/openai.yml` import
- `api-key` 등 시크릿 값을 `application.yaml`에서 제거

## 변경 이유
시크릿 값을 private 레포(backend-config)로 분리 관리

Closes #10