### PR TITLE
feat: serve refreshToken as HttpOnly cookie

### DIFF
--- a/src/main/java/com/aac/backend/presentation/AuthController.java
+++ b/src/main/java/com/aac/backend/presentation/AuthController.java
@@ -1,16 +1,16 @@
 package com.aac.backend.presentation;
 
-import com.aac.backend.presentation.dto.request.ReissueRequest;
+import com.aac.backend.presentation.cookie.RefreshTokenCookieProvider;
 import com.aac.backend.presentation.dto.response.ApiResponse;
 import com.aac.backend.presentation.dto.response.TokenResponse;
 import com.aac.backend.service.AuthService;
 import com.aac.backend.service.GoogleAuthService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,22 +22,30 @@ public class AuthController {
 
     private final AuthService authService;
     private final GoogleAuthService googleAuthService;
+    private final RefreshTokenCookieProvider cookieProvider;
 
     @GetMapping("/google/callback")
     public ResponseEntity<ApiResponse<TokenResponse>> googleCallback(@RequestParam String code) {
         var tokens = googleAuthService.login(code);
-        return ResponseEntity.ok(ApiResponse.success(tokens));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookieProvider.createCookie(tokens.refreshToken()).toString())
+                .body(ApiResponse.success(new TokenResponse(tokens.accessToken())));
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<TokenResponse>> reissue(@Valid @RequestBody ReissueRequest request) {
-        var tokens = authService.reissue(request.refreshToken());
-        return ResponseEntity.ok(ApiResponse.success(tokens));
+    public ResponseEntity<ApiResponse<TokenResponse>> reissue(
+            @CookieValue(RefreshTokenCookieProvider.REFRESH_TOKEN_COOKIE) String refreshToken
+    ) {
+        var tokens = authService.reissue(refreshToken);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookieProvider.createCookie(tokens.refreshToken()).toString())
+                .body(ApiResponse.success(new TokenResponse(tokens.accessToken())));
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@Valid @RequestBody ReissueRequest request) {
-        authService.logout(request.refreshToken());
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, cookieProvider.clearCookie().toString())
+                .build();
     }
 }

--- a/src/main/java/com/aac/backend/presentation/cookie/RefreshTokenCookieProvider.java
+++ b/src/main/java/com/aac/backend/presentation/cookie/RefreshTokenCookieProvider.java
@@ -1,0 +1,29 @@
+package com.aac.backend.presentation.cookie;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenCookieProvider {
+
+    public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+
+    public ResponseCookie createCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/api/auth")
+                .build();
+    }
+
+    public ResponseCookie clearCookie() {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/api/auth")
+                .maxAge(0)
+                .build();
+    }
+}

--- a/src/main/java/com/aac/backend/presentation/dto/request/ReissueRequest.java
+++ b/src/main/java/com/aac/backend/presentation/dto/request/ReissueRequest.java
@@ -1,6 +1,0 @@
-package com.aac.backend.presentation.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record ReissueRequest(@NotBlank String refreshToken) {
-}

--- a/src/main/java/com/aac/backend/presentation/dto/response/TokenResponse.java
+++ b/src/main/java/com/aac/backend/presentation/dto/response/TokenResponse.java
@@ -1,4 +1,3 @@
 package com.aac.backend.presentation.dto.response;
 
-public record TokenResponse(String accessToken, String refreshToken) {
-}
+public record TokenResponse(String accessToken) {}

--- a/src/main/java/com/aac/backend/service/AuthService.java
+++ b/src/main/java/com/aac/backend/service/AuthService.java
@@ -5,7 +5,6 @@ import com.aac.backend.domain.RefreshTokenRepository;
 import com.aac.backend.global.exception.BusinessException;
 import com.aac.backend.global.exception.ErrorCode;
 import com.aac.backend.infra.jwt.JwtProvider;
-import com.aac.backend.presentation.dto.response.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,8 +16,10 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    public record AuthTokens(String accessToken, String refreshToken) {}
+
     @Transactional
-    public TokenResponse reissue(String refreshTokenValue) {
+    public AuthTokens reissue(String refreshTokenValue) {
         var refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
 
@@ -33,19 +34,13 @@ public class AuthService {
         var newAccessToken = jwtProvider.issue(userId);
         var newRefreshToken = issueAndSaveRefreshToken(userId);
 
-        return new TokenResponse(newAccessToken, newRefreshToken);
+        return new AuthTokens(newAccessToken, newRefreshToken);
     }
 
-    public TokenResponse issueTokens(Long userId) {
+    public AuthTokens issueTokens(Long userId) {
         var accessToken = jwtProvider.issue(userId);
         var refreshToken = issueAndSaveRefreshToken(userId);
-        return new TokenResponse(accessToken, refreshToken);
-    }
-
-    @Transactional
-    public void logout(String refreshTokenValue) {
-        refreshTokenRepository.findByToken(refreshTokenValue)
-                .ifPresent(refreshTokenRepository::delete);
+        return new AuthTokens(accessToken, refreshToken);
     }
 
     private String issueAndSaveRefreshToken(Long userId) {

--- a/src/main/java/com/aac/backend/service/GoogleAuthService.java
+++ b/src/main/java/com/aac/backend/service/GoogleAuthService.java
@@ -3,7 +3,7 @@ package com.aac.backend.service;
 import com.aac.backend.domain.User;
 import com.aac.backend.domain.UserRepository;
 import com.aac.backend.infra.oauth.GoogleOAuthClient;
-import com.aac.backend.presentation.dto.response.TokenResponse;
+import com.aac.backend.service.AuthService.AuthTokens;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ public class GoogleAuthService {
     private final AuthService authService;
 
     @Transactional
-    public TokenResponse login(String code) {
+    public AuthTokens login(String code) {
         var userInfo = googleOAuthClient.getUserInfo(code);
         var user = userRepository.findByEmail(userInfo.email())
                 .orElseGet(() -> userRepository.save(


### PR DESCRIPTION
## 작업 내용
- refreshToken을 response body 대신 HttpOnly 쿠키로 전달
- `POST /auth/refresh` → body 대신 쿠키에서 refreshToken 읽기
- `POST /auth/logout` → 아무것도 받지 않고 쿠키만 삭제 (DB 정리는 TTL 스케줄러에 위임)
- `RefreshTokenCookieProvider` 유틸 추가
- `ReissueRequest` 삭제

## 변경 이유
refreshToken을 body로 내리면 JS 접근 가능 → XSS 취약. HttpOnly 쿠키로 전환

Closes #12