### PR TITLE
chore: 설정 파일 서브모듈 분리 및 AI 통합 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,5 +43,15 @@ dependencies {
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'ai'
+    }
+}
+
+tasks.register('aiTest', Test) {
+    useJUnitPlatform {
+        includeTags 'ai'
+    }
+    group = 'verification'
+    description = 'Run AI integration tests (requires API key)'
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,13 +1,13 @@
 spring:
   datasource:
-    url: ${db.local.url}
-    username: ${db.local.username}
-    password: ${db.local.password}
-    driver-class-name: ${db.local.driver-class-name}
+    url: jdbc:h2:mem:aac
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: ${db.local.ddl-auto}
-    show-sql: ${db.local.show-sql}
+      ddl-auto: update
+    show-sql: true
   h2:
     console:
       enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,14 +1,13 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:aac
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    url: ${db.local.url}
+    username: ${db.local.username}
+    password: ${db.local.password}
+    driver-class-name: ${db.local.driver-class-name}
   jpa:
     hibernate:
-      ddl-auto: update
-      dialect: org.hibernate.dialect.H2Dialect
-    show-sql: true
+      ddl-auto: ${db.local.ddl-auto}
+    show-sql: ${db.local.show-sql}
   h2:
     console:
       enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,10 +1,10 @@
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${db.prod.url}
+    username: ${db.prod.username}
+    password: ${db.prod.password}
+    driver-class-name: ${db.prod.driver-class-name}
   jpa:
     hibernate:
-      ddl-auto: validate
-    show-sql: false
+      ddl-auto: ${db.prod.ddl-auto}
+    show-sql: ${db.prod.show-sql}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,8 +8,10 @@ spring:
       - config/jwt.yml
       - config/oidc.yml
       - config/openai.yml
+      - config/db.yml
   ai:
     openai:
+      api-key: ${spring.ai.openai.api-key}
       chat:
         options:
           model: gpt-4o
@@ -17,6 +19,21 @@ spring:
       embedding:
         options:
           model: text-embedding-3-small
+jwt:
+  secret: ${jwt.secret}
+  expiration-ms: ${jwt.expiration-ms}
+  refresh-expiration-ms: ${jwt.refresh-expiration-ms}
+
+oidc:
+  google:
+    client-id: ${oidc.google.client-id}
+    client-secret: ${oidc.google.client-secret}
+    token-uri: ${oidc.google.token-uri}
+    user-uri: ${oidc.google.user-uri}
+    redirect-uri: ${oidc.google.redirect-uri}
+    connect-timeout: ${oidc.google.connect-timeout}
+    read-timeout: ${oidc.google.read-timeout}
+
 cors:
   allowed-origins:
     - http://localhost:5173

--- a/src/test/java/com/aac/backend/infra/WordSentenceGeneratorIntegrationTest.java
+++ b/src/test/java/com/aac/backend/infra/WordSentenceGeneratorIntegrationTest.java
@@ -1,0 +1,45 @@
+package com.aac.backend.infra;
+
+import com.aac.backend.presentation.dto.request.WordRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("ai")
+@SpringBootTest
+@ActiveProfiles("local")
+class WordSentenceGeneratorIntegrationTest {
+
+    @Autowired
+    private WordSentenceGenerator wordSentenceGenerator;
+
+    @Test
+    void 단어_목록을_자연스러운_문장으로_변환한다() {
+        var words = List.of(
+                new WordRequest("감정", "배고파"),
+                new WordRequest("음식", "밥"),
+                new WordRequest("행동", "먹고싶어")
+        );
+
+        var result = wordSentenceGenerator.generate(words);
+
+        System.out.println("생성된 문장: " + result);
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
+    void 단일_단어도_문장으로_변환한다() {
+        var words = List.of(new WordRequest("장소", "학교"));
+
+        var result = wordSentenceGenerator.generate(words);
+
+        System.out.println("생성된 문장: " + result);
+        assertThat(result).isNotBlank();
+    }
+}

--- a/src/test/java/com/aac/backend/infra/WordSentenceGeneratorIntegrationTest.java
+++ b/src/test/java/com/aac/backend/infra/WordSentenceGeneratorIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.aac.backend.infra;
 
+import com.aac.backend.domain.ConversationMessage;
 import com.aac.backend.presentation.dto.request.WordRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class WordSentenceGeneratorIntegrationTest {
                 new WordRequest("행동", "먹고싶어")
         );
 
-        var result = wordSentenceGenerator.generate(words);
+        var result = wordSentenceGenerator.generate(words, List.of());
 
         System.out.println("생성된 문장: " + result);
         assertThat(result).isNotBlank();
@@ -37,7 +38,7 @@ class WordSentenceGeneratorIntegrationTest {
     void 단일_단어도_문장으로_변환한다() {
         var words = List.of(new WordRequest("장소", "학교"));
 
-        var result = wordSentenceGenerator.generate(words);
+        var result = wordSentenceGenerator.generate(words, List.of());
 
         System.out.println("생성된 문장: " + result);
         assertThat(result).isNotBlank();


### PR DESCRIPTION
## 작업 내용
- application.yaml에 openai, jwt, oidc, db 프로퍼티 명시적 참조 추가
- DB 설정(로컬 H2, 프로드 MySQL)을 단일 config/db.yml로 서브모듈 분리 (local/prod 네임스페이스 구분)
- WordSentenceGenerator AI 통합 테스트 추가 (@Tag("ai")로 CI 제외)
- build.gradle에 aiTest 태스크 추가

## 변경 이유
시크릿 및 설정값을 서브모듈에서 관리하고, application.yaml에서 명시적으로 참조하여 어떤 프로퍼티가 쓰이는지 한눈에 파악할 수 있도록 개선

Closes #14