### PR TITLE
refactor: externalize system prompt to config submodule

### DIFF
--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -2,9 +2,9 @@ package com.aac.backend.infra;
 
 import com.aac.backend.domain.ConversationMessage;
 import com.aac.backend.presentation.dto.request.WordRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -15,11 +15,17 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class WordSentenceGenerator {
 
     private final ChatClient chatClient;
+    private final String systemPrompt;
+
+    public WordSentenceGenerator(ChatClient chatClient,
+                                 @Value("${prompts.sentence}") String systemPrompt) {
+        this.chatClient = chatClient;
+        this.systemPrompt = systemPrompt;
+    }
 
     public String generate(List<WordRequest> wordRequests, List<ConversationMessage> history) {
         var symbols = formatWords(wordRequests);
@@ -32,29 +38,7 @@ public class WordSentenceGenerator {
         }
 
         var response = chatClient.prompt()
-                .system("""
-                        당신은 발달장애인의 의사소통을 돕는 AAC 시스템입니다.
-                        사용자가 선택한 기호 목록을 자연스러운 한국어 문장 1개로 변환하세요.
-                        이전 대화 내용이 있다면 맥락을 반영하세요.
-
-                        규칙:
-                        - 입력된 기호를 모두 포함해야 합니다.
-                        - 기호를 임의로 추가하거나 생략하지 마세요.
-                        - 기호 순서를 최대한 유지하세요.
-                        - 문장은 1인칭 기준으로 작성하세요.
-                        - 간결하고 자연스러운 구어체로 작성하세요.
-                        - 문장만 출력하세요.
-
-                        예시:
-                        입력: [감정] 배고파, [음식] 밥, [행동] 먹고싶어
-                        출력: 나 배고파, 밥 먹고 싶어.
-
-                        입력: [장소] 학교, [행동] 가고싶어
-                        출력: 나 학교 가고 싶어.
-
-                        입력: [음식] 물, [행동] 먹고싶어
-                        출력: 나 물 마시고 싶어.
-                        """)
+                .system(systemPrompt)
                 .messages(messages)
                 .user(symbols)
                 .call()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ spring:
       - config/oidc.yml
       - config/openai.yml
       - config/db.yml
+      - config/prompts.yml
   ai:
     openai:
       api-key: ${spring.ai.openai.api-key}
@@ -33,6 +34,9 @@ oidc:
     redirect-uri: ${oidc.google.redirect-uri}
     connect-timeout: ${oidc.google.connect-timeout}
     read-timeout: ${oidc.google.read-timeout}
+
+prompts:
+  sentence: ${prompts.sentence}
 
 cors:
   allowed-origins:


### PR DESCRIPTION
## 작업 내용
- 하드코딩된 시스템 프롬프트를 config 서브모듈의 prompts.yml로 외부화
- application.yaml에 prompts.sentence 바인딩 추가

## 변경 이유
프롬프트 수정 시 코드 변경 없이 서브모듈에서 관리 가능

Closes #$(gh issue list --repo AAC-ai/backend --search "externalize" --json number --jq '.[0].number' 2>/dev/null || echo "")