### PR TITLE
docs: config 서브모듈 설정 문서 추가

### DIFF
--- a/docs/config-submodule.md
+++ b/docs/config-submodule.md
@@ -1,0 +1,57 @@
+# Config Submodule Setup
+
+The application imports environment-specific configuration from the private
+`AAC-ai/backend-config` repository mounted at:
+
+```text
+src/main/resources/config
+```
+
+If this directory is empty, Spring Boot cannot load files such as `jwt.yml`,
+`oidc.yml`, `openai.yml`, `db.yml`, and `prompts.yml`. In that case tests or
+local startup can fail with `ConfigDataResourceNotFoundException`.
+
+## Local Setup
+
+Initialize the config submodule after cloning this repository:
+
+```bash
+git submodule update --init --recursive
+```
+
+To refresh it later:
+
+```bash
+git submodule update --remote --recursive
+```
+
+If GitHub prompts for authentication, use a GitHub account or token that can
+read the private `AAC-ai/backend-config` repository.
+
+## CI Setup
+
+GitHub Actions checks out the private submodule with:
+
+```yaml
+submodules: true
+token: ${{ secrets.SUBMODULE_TOKEN }}
+```
+
+The `AAC-ai/backend` repository must define this Actions secret:
+
+```text
+SUBMODULE_TOKEN=<GitHub PAT with read access to AAC-ai/backend-config>
+```
+
+Use a fine-grained personal access token with the smallest scope possible:
+
+```text
+Resource owner: AAC-ai
+Repository access: Only select repositories
+Repository: backend-config
+Repository permissions:
+  Contents: Read-only
+```
+
+Do not commit real config files, tokens, database passwords, or other secrets
+directly to this repository.


### PR DESCRIPTION
## 작업 내용
- config 서브모듈 초기화/갱신 명령 문서화
- CI에서 필요한 `SUBMODULE_TOKEN` 설정과 최소 권한 문서화
- 실제 config/secrets를 backend repo에 커밋하지 말라는 주의 추가

## 변경 이유
로컬/CI 환경에서 `src/main/resources/config` 서브모듈이 비어 있으면 Spring config import가 실패하므로, 초기화 절차와 GitHub Actions secret 요구사항을 명확히 하기 위함입니다.

## 테스트
- `git submodule update --init --recursive`: passed
- `./gradlew test`: passed

Closes #27