### PR TITLE
fix: Docker Hub 이미지 경로 수정

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: aac-ai/backend:latest
+          tags: accoknu/backend:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       - was
 
   was:
-    image: aac-ai/backend:latest
+    image: accoknu/backend:latest
     expose:
       - "8080"
     environment:


### PR DESCRIPTION
## 작업 내용
- CI Publish Docker image tag를 `accoknu/backend:latest`로 변경
- production compose의 WAS image를 `accoknu/backend:latest`로 변경

## 변경 이유
- 실제 Docker Hub namespace가 `accoknu`라서 `aac-ai/backend:latest` push가 권한 오류로 실패했습니다.

## 테스트
- `./gradlew test`: passed

Closes #31