### PR TITLE
fix: ARM64 Docker 이미지 빌드 설정 추가

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -38,9 +38,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/arm64
           push: true
           tags: accoknu/backend:latest


### PR DESCRIPTION
## 작업 내용
- CI Publish에 QEMU/Buildx setup을 추가했습니다.
- Docker image build platform을 `linux/arm64`로 지정했습니다.

## 변경 이유
- self-hosted runner/EC2가 ARM64 환경인데 기존 Docker image가 AMD64로 빌드되어 `exec format error`로 WAS 컨테이너가 종료됐습니다.

## 테스트
- `./gradlew test`: passed

Closes #35