### PR TITLE
fix: Caddy 도메인 환경변수 설정

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -25,6 +25,6 @@ jobs:
 
       - name: Deploy
         run: |
-          docker compose -f docker-compose.prod.yml pull
-          docker compose -f docker-compose.prod.yml up -d
+          DOMAIN=aaco.kr docker compose -f docker-compose.prod.yml pull
+          DOMAIN=aaco.kr docker compose -f docker-compose.prod.yml up -d
           docker image prune -f

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN:-aaco.kr}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - ./frontend:/srv/frontend:ro


### PR DESCRIPTION
## 작업 내용
- production compose의 Caddy 서비스에 `DOMAIN` 환경변수를 추가했습니다.
- CD Deploy에서 `DOMAIN=aaco.kr`를 명시해 compose pull/up을 실행하도록 변경했습니다.

## 변경 이유
- Caddyfile이 `{$DOMAIN}`을 사용하지만 배포 시 값이 비어 Caddy가 `handle`을 global option으로 해석하고 종료됐습니다.

## 테스트
- `./gradlew test`: passed

Closes #38