### PR TITLE
fix: api 도메인 Caddy 라우팅 추가

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -25,6 +25,6 @@ jobs:
 
       - name: Deploy
         run: |
-          DOMAIN=aaco.kr docker compose -f docker-compose.prod.yml pull
-          DOMAIN=aaco.kr docker compose -f docker-compose.prod.yml up -d
+          docker compose -f docker-compose.prod.yml pull
+          docker compose -f docker-compose.prod.yml up -d
           docker image prune -f

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-{$DOMAIN} {
+aaco.kr, api.aaco.kr {
     handle /api/* {
         reverse_proxy was:8080
     }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,8 +4,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    environment:
-      DOMAIN: ${DOMAIN:-aaco.kr}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - ./frontend:/srv/frontend:ro


### PR DESCRIPTION
## 작업 내용
- Caddy site label을 `aaco.kr, api.aaco.kr`로 명시했습니다.
- DOMAIN 환경변수 의존성을 제거했습니다.
- `https://api.aaco.kr/api/...` 요청이 WAS로 프록시되도록 설정했습니다.

## 변경 이유
- API 서버 도메인을 `api.aaco.kr`로 사용해야 하기 때문입니다.

## 테스트
- `./gradlew test`: passed

Closes #40