### PR TITLE
fix: 운영 프론트 CORS origin 추가

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,3 +42,4 @@ cors:
   allowed-origins:
     - http://localhost:5173
     - http://127.0.0.1:5173
+    - https://aaco.kr


### PR DESCRIPTION
## 작업 내용
- CORS allowed origins에 `https://aaco.kr`를 추가했습니다.

## 변경 이유
- 운영 프론트에서 `https://api.aaco.kr/api` 호출 시 CORS 오류가 발생했기 때문입니다.

## 테스트
- `./gradlew test`: passed

Closes #42