### PR TITLE
fix: www 도메인 허용 및 500 로깅 추가

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-aaco.kr, api.aaco.kr {
+aaco.kr, www.aaco.kr, api.aaco.kr {
     handle /api/* {
         reverse_proxy was:8080
     }

--- a/src/main/java/com/aac/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aac/backend/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package com.aac.backend.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -22,6 +24,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled exception occurred", e);
         return ResponseEntity.internalServerError().body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,3 +43,4 @@ cors:
     - http://localhost:5173
     - http://127.0.0.1:5173
     - https://aaco.kr
+    - https://www.aaco.kr


### PR DESCRIPTION
## 작업 내용
- Caddy site label에 `www.aaco.kr`를 추가했습니다.
- CORS allowed origins에 `https://www.aaco.kr`를 추가했습니다.
- 예상하지 못한 500 예외 발생 시 stack trace가 서버 로그에 남도록 `GlobalExceptionHandler`에 error logging을 추가했습니다.

## 변경 이유
- `www.aaco.kr`에서 프론트가 API를 호출할 때 CORS가 통과해야 합니다.
- 운영 500 에러 원인 분석을 위해 stack trace 로그가 필요합니다.

## 테스트
- `./gradlew test`: passed

Closes #44