### PR TITLE
fix: Google OAuth redirect_uri 환경변수 → 실제 값으로 교체

### DIFF
--- a/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
+++ b/src/main/java/com/aac/backend/infra/oauth/GoogleOAuthProperties.java
@@ -9,26 +9,32 @@ public class GoogleOAuthProperties {
 
     private final String clientId;
     private final String clientSecret;
+    private final String authorizationUri;
     private final String tokenUri;
     private final String userUri;
     private final String redirectUri;
+    private final String successRedirectUri;
     private final int connectTimeout;
     private final int readTimeout;
 
     public GoogleOAuthProperties(
             final String clientId,
             final String clientSecret,
+            final String authorizationUri,
             final String tokenUri,
             final String userUri,
             final String redirectUri,
+            final String successRedirectUri,
             final int connectTimeout,
             final int readTimeout
     ) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.authorizationUri = authorizationUri;
         this.tokenUri = tokenUri;
         this.userUri = userUri;
         this.redirectUri = redirectUri;
+        this.successRedirectUri = successRedirectUri;
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
     }

--- a/src/main/java/com/aac/backend/presentation/AuthController.java
+++ b/src/main/java/com/aac/backend/presentation/AuthController.java
@@ -6,6 +6,7 @@ import com.aac.backend.service.AuthService;
 import com.aac.backend.service.GoogleAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,14 +26,22 @@ public class AuthController {
     private final GoogleAuthService googleAuthService;
     private final TokenCookieProvider cookieProvider;
 
+    @GetMapping("/google")
+    public ResponseEntity<Void> redirectToGoogle() {
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(googleAuthService.getAuthorizationUrl()))
+                .build();
+    }
+
     @GetMapping("/google/callback")
-    public ResponseEntity<ApiResponse<Void>> googleCallback(@RequestParam String code) {
+    public ResponseEntity<Void> googleCallback(@RequestParam String code) {
         var tokens = googleAuthService.login(code);
-        return ResponseEntity.ok()
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(googleAuthService.getSuccessRedirectUri()))
                 .header(HttpHeaders.SET_COOKIE,
                         cookieProvider.createAccessTokenCookie(tokens.accessToken()).toString(),
                         cookieProvider.createRefreshTokenCookie(tokens.refreshToken()).toString())
-                .body(ApiResponse.success(null));
+                .build();
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/aac/backend/service/GoogleAuthService.java
+++ b/src/main/java/com/aac/backend/service/GoogleAuthService.java
@@ -3,18 +3,36 @@ package com.aac.backend.service;
 import com.aac.backend.domain.User;
 import com.aac.backend.domain.UserRepository;
 import com.aac.backend.infra.oauth.GoogleOAuthClient;
+import com.aac.backend.infra.oauth.GoogleOAuthProperties;
 import com.aac.backend.service.AuthService.AuthTokens;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
 public class GoogleAuthService {
 
     private final GoogleOAuthClient googleOAuthClient;
+    private final GoogleOAuthProperties googleOAuthProperties;
     private final UserRepository userRepository;
     private final AuthService authService;
+
+    public String getAuthorizationUrl() {
+        return UriComponentsBuilder.fromUriString(googleOAuthProperties.getAuthorizationUri())
+                .queryParam("client_id", googleOAuthProperties.getClientId())
+                .queryParam("redirect_uri", googleOAuthProperties.getRedirectUri())
+                .queryParam("response_type", "code")
+                .queryParam("scope", "openid email profile")
+                .build()
+                .encode()
+                .toUriString();
+    }
+
+    public String getSuccessRedirectUri() {
+        return googleOAuthProperties.getSuccessRedirectUri();
+    }
 
     @Transactional
     public AuthTokens login(String code) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,9 +29,11 @@ oidc:
   google:
     client-id: ${oidc.google.client-id}
     client-secret: ${oidc.google.client-secret}
+    authorization-uri: ${oidc.google.authorization-uri}
     token-uri: ${oidc.google.token-uri}
     user-uri: ${oidc.google.user-uri}
     redirect-uri: ${oidc.google.redirect-uri}
+    success-redirect-uri: ${oidc.google.success-redirect-uri}
     connect-timeout: ${oidc.google.connect-timeout}
     read-timeout: ${oidc.google.read-timeout}
 


### PR DESCRIPTION
## 작업 내용
- `oidc.yml` 서브모듈의 `redirect-uri`를 `${GOOGLE_REDIRECT_URI}` 환경변수에서 실제 값으로 교체
- 백엔드 구글 로그인 리다이렉트 설정 추가

## 변경 이유
프로덕션 서버에 `GOOGLE_REDIRECT_URI` 환경변수가 설정되어 있지 않아 `redirect_uri=${GOOGLE_REDIRECT_URI}` 문자열이 그대로 전달되어 `400 invalid_request` 에러 발생

## 테스트
- Google OAuth 로그인 흐름 확인 필요