### PR TITLE
refactor: 대화 컨텍스트 로딩 방식 개선

### DIFF
--- a/src/main/java/com/aac/backend/domain/ConversationMessageRepository.java
+++ b/src/main/java/com/aac/backend/domain/ConversationMessageRepository.java
@@ -1,13 +1,15 @@
 package com.aac.backend.domain;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ConversationMessageRepository extends JpaRepository<ConversationMessage, Long> {
 
-    List<ConversationMessage> findTop10ByUserIdOrderByCreatedAtAsc(Long userId);
-
-    boolean existsByUserIdAndCreatedAtAfter(Long userId, LocalDateTime threshold);
+    @Query("SELECT c FROM ConversationMessage c WHERE c.user.id = :userId AND c.createdAt > :threshold ORDER BY c.createdAt ASC")
+    List<ConversationMessage> findRecentContext(@Param("userId") Long userId, @Param("threshold") LocalDateTime threshold, Pageable pageable);
 }

--- a/src/main/java/com/aac/backend/domain/ConversationMessageRepository.java
+++ b/src/main/java/com/aac/backend/domain/ConversationMessageRepository.java
@@ -2,9 +2,12 @@ package com.aac.backend.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ConversationMessageRepository extends JpaRepository<ConversationMessage, Long> {
 
     List<ConversationMessage> findTop10ByUserIdOrderByCreatedAtAsc(Long userId);
+
+    boolean existsByUserIdAndCreatedAtAfter(Long userId, LocalDateTime threshold);
 }

--- a/src/main/java/com/aac/backend/service/ConversationContextProperties.java
+++ b/src/main/java/com/aac/backend/service/ConversationContextProperties.java
@@ -1,0 +1,8 @@
+package com.aac.backend.service;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "conversation.context")
+public record ConversationContextProperties(int limit, int thresholdHours) {
+
+}

--- a/src/main/java/com/aac/backend/service/WordService.java
+++ b/src/main/java/com/aac/backend/service/WordService.java
@@ -12,11 +12,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class WordService {
+
+    private static final int SESSION_EXPIRY_HOURS = 4;
 
     private final WordSentenceGenerator wordSentenceGenerator;
     private final ConversationMessageRepository conversationMessageRepository;
@@ -25,6 +28,7 @@ public class WordService {
     @Transactional
     public String generateSentence(List<WordRequest> words, LoginUser loginUser) {
         var history = loginUser.userId()
+                .filter(this::isSessionAlive)
                 .map(conversationMessageRepository::findTop10ByUserIdOrderByCreatedAtAsc)
                 .orElse(List.of());
 
@@ -33,6 +37,11 @@ public class WordService {
         loginUser.userId().ifPresent(id -> saveConversationHistory(id, words, sentence));
 
         return sentence;
+    }
+
+    private boolean isSessionAlive(Long userId) {
+        var threshold = LocalDateTime.now().minusHours(SESSION_EXPIRY_HOURS);
+        return conversationMessageRepository.existsByUserIdAndCreatedAtAfter(userId, threshold);
     }
 
     private void saveConversationHistory(Long userId, List<WordRequest> words, String sentence) {

--- a/src/main/java/com/aac/backend/service/WordService.java
+++ b/src/main/java/com/aac/backend/service/WordService.java
@@ -9,6 +9,8 @@ import com.aac.backend.infra.WordSentenceGenerator;
 import com.aac.backend.presentation.argumentresolver.LoginUser;
 import com.aac.backend.presentation.dto.request.WordRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,19 +19,18 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@EnableConfigurationProperties(ConversationContextProperties.class)
 public class WordService {
-
-    private static final int SESSION_EXPIRY_HOURS = 4;
 
     private final WordSentenceGenerator wordSentenceGenerator;
     private final ConversationMessageRepository conversationMessageRepository;
     private final UserRepository userRepository;
+    private final ConversationContextProperties contextProperties;
 
     @Transactional
     public String generateSentence(List<WordRequest> words, LoginUser loginUser) {
         var history = loginUser.userId()
-                .filter(this::isSessionAlive)
-                .map(conversationMessageRepository::findTop10ByUserIdOrderByCreatedAtAsc)
+                .map(this::loadContext)
                 .orElse(List.of());
 
         var sentence = wordSentenceGenerator.generate(words, history);
@@ -39,9 +40,11 @@ public class WordService {
         return sentence;
     }
 
-    private boolean isSessionAlive(Long userId) {
-        var threshold = LocalDateTime.now().minusHours(SESSION_EXPIRY_HOURS);
-        return conversationMessageRepository.existsByUserIdAndCreatedAtAfter(userId, threshold);
+    private List<ConversationMessage> loadContext(Long userId) {
+        var threshold = LocalDateTime.now().minusHours(contextProperties.thresholdHours());
+        return conversationMessageRepository.findRecentContext(
+                userId, threshold, PageRequest.of(0, contextProperties.limit())
+        );
     }
 
     private void saveConversationHistory(Long userId, List<WordRequest> words, String sentence) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
       - config/openai.yml
       - config/db.yml
       - config/prompts.yml
+      - config/conversation.yml
   ai:
     openai:
       api-key: ${spring.ai.openai.api-key}


### PR DESCRIPTION
## 작업 내용
- 세션 생존 여부 체크 방식 제거
- 최근 N개 & 시간 임계값 이내 메시지만 컨텍스트로 로드하도록 변경
- 설정값(`limit`, `threshold-hours`) 서브모듈 `conversation.yml`로 관리

## 변경 이유
기존 세션 alive/dead 이분법 대신 메시지 단위로 필터링하는 방식이 더 자연스럽고 유연함

## 테스트
- `./gradlew build -x test` 통과

Closes #