### PR TITLE
feat: AI 응답 트레이싱 추가

### DIFF
--- a/src/main/java/com/aac/backend/BackendApplication.java
+++ b/src/main/java/com/aac/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package com.aac.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication

--- a/src/main/java/com/aac/backend/analytics/AiGenerationLog.java
+++ b/src/main/java/com/aac/backend/analytics/AiGenerationLog.java
@@ -1,0 +1,69 @@
+package com.aac.backend.analytics;
+
+import com.aac.backend.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "ai_generation_logs")
+public class AiGenerationLog extends BaseEntity {
+
+    @Id
+    private String traceId;
+
+    private Integer wordCount;
+
+    @Column(columnDefinition = "TEXT")
+    private String selectedWords;
+
+    private String model;
+
+    private Long latencyMs;
+
+    @Column(columnDefinition = "TEXT")
+    private String contextMessages;
+
+    private Boolean success;
+
+    private String failureReason;
+
+    private Integer promptTokens;
+
+    private Integer completionTokens;
+
+    private Integer totalTokens;
+
+    private AiGenerationLog(String traceId, Integer wordCount, String selectedWords,
+                             String model, Long latencyMs, String contextMessages,
+                             Boolean success, String failureReason,
+                             Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+        this.traceId = traceId;
+        this.wordCount = wordCount;
+        this.selectedWords = selectedWords;
+        this.model = model;
+        this.latencyMs = latencyMs;
+        this.contextMessages = contextMessages;
+        this.success = success;
+        this.failureReason = failureReason;
+        this.promptTokens = promptTokens;
+        this.completionTokens = completionTokens;
+        this.totalTokens = totalTokens;
+    }
+
+    public static AiGenerationLog success(String traceId, Integer wordCount, String selectedWords,
+                                          String model, Long latencyMs, String contextMessages,
+                                          Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+        return new AiGenerationLog(traceId, wordCount, selectedWords, model, latencyMs, contextMessages,
+                true, null, promptTokens, completionTokens, totalTokens);
+    }
+
+    public static AiGenerationLog failure(String traceId, Integer wordCount, String selectedWords,
+                                          String model, Long latencyMs, String contextMessages, String failureReason) {
+        return new AiGenerationLog(traceId, wordCount, selectedWords, model, latencyMs, contextMessages,
+                false, failureReason, null, null, null);
+    }
+}

--- a/src/main/java/com/aac/backend/analytics/AiGenerationLogEvent.java
+++ b/src/main/java/com/aac/backend/analytics/AiGenerationLogEvent.java
@@ -1,0 +1,16 @@
+package com.aac.backend.analytics;
+
+import com.aac.backend.domain.ConversationMessage;
+import com.aac.backend.infra.GenerationResult;
+import com.aac.backend.presentation.dto.request.WordRequest;
+
+import java.util.List;
+
+public record AiGenerationLogEvent(
+        String traceId,
+        List<WordRequest> words,
+        List<ConversationMessage> contextMessages,
+        GenerationResult result
+) {
+
+}

--- a/src/main/java/com/aac/backend/analytics/AiGenerationLogEventListener.java
+++ b/src/main/java/com/aac/backend/analytics/AiGenerationLogEventListener.java
@@ -1,0 +1,61 @@
+package com.aac.backend.analytics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiGenerationLogEventListener {
+
+    private final AiGenerationLogRepository aiGenerationLogRepository;
+    private final ObjectMapper objectMapper;
+
+    @Async
+    @EventListener
+    @Transactional
+    public void handle(AiGenerationLogEvent event) {
+        log.info("AI 생성 로그 저장 시작 - traceId: {}, thread: {}", event.traceId(), Thread.currentThread().getName());
+        try {
+            var words = event.words();
+            var result = event.result();
+            var selectedWords = words.stream()
+                    .map(w -> "[" + w.category() + "] " + w.label())
+                    .collect(Collectors.joining(", "));
+            var contextMessages = serializeContext(event.contextMessages());
+
+            var generationLog = result.success()
+                    ? AiGenerationLog.success(event.traceId(), words.size(), selectedWords, result.model(), result.latencyMs(), contextMessages,
+                            result.promptTokens(), result.completionTokens(), result.totalTokens())
+                    : AiGenerationLog.failure(event.traceId(), words.size(), selectedWords, result.model(), result.latencyMs(), contextMessages, result.failureReason());
+
+            aiGenerationLogRepository.save(generationLog);
+        } catch (Exception e) {
+            log.error("AI 생성 로그 저장 실패 - traceId: {}", event.traceId(), e);
+        }
+    }
+
+    private String serializeContext(List<com.aac.backend.domain.ConversationMessage> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return null;
+        }
+        try {
+            var list = messages.stream()
+                    .map(m -> Map.of("userInput", m.getUserInput(), "aiResponse", m.getAiResponse()))
+                    .collect(Collectors.toList());
+            return objectMapper.writeValueAsString(list);
+        } catch (Exception e) {
+            log.warn("컨텍스트 직렬화 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/aac/backend/analytics/AiGenerationLogRepository.java
+++ b/src/main/java/com/aac/backend/analytics/AiGenerationLogRepository.java
@@ -1,0 +1,7 @@
+package com.aac.backend.analytics;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiGenerationLogRepository extends JpaRepository<AiGenerationLog, String> {
+
+}

--- a/src/main/java/com/aac/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/aac/backend/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "리소스를 찾을 수 없습니다."),
+    AI_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI_GENERATION_FAILED", "AI 문장 생성에 실패했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/aac/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aac/backend/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package com.aac.backend.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -20,6 +22,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Void> handleNoResourceFoundException(NoResourceFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/aac/backend/infra/GenerationResult.java
+++ b/src/main/java/com/aac/backend/infra/GenerationResult.java
@@ -1,0 +1,22 @@
+package com.aac.backend.infra;
+
+public record GenerationResult(
+        String sentence,
+        String model,
+        long latencyMs,
+        boolean success,
+        String failureReason,
+        Integer promptTokens,
+        Integer completionTokens,
+        Integer totalTokens
+) {
+
+    public static GenerationResult success(String sentence, String model, long latencyMs,
+                                           Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+        return new GenerationResult(sentence, model, latencyMs, true, null, promptTokens, completionTokens, totalTokens);
+    }
+
+    public static GenerationResult failure(String model, long latencyMs, String failureReason) {
+        return new GenerationResult(null, model, latencyMs, false, failureReason, null, null, null);
+    }
+}

--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -27,7 +27,7 @@ public class WordSentenceGenerator {
         this.systemPrompt = systemPrompt;
     }
 
-    public String generate(List<WordRequest> wordRequests, List<ConversationMessage> history) {
+    public GenerationResult generate(List<WordRequest> wordRequests, List<ConversationMessage> history) {
         var symbols = formatWords(wordRequests);
         log.info("symbols: {}", symbols);
 
@@ -37,20 +37,33 @@ public class WordSentenceGenerator {
             messages.add(new AssistantMessage(msg.getAiResponse()));
         }
 
-        var response = chatClient.prompt()
-                .system(systemPrompt)
-                .messages(messages)
-                .user(symbols)
-                .call()
-                .chatResponse();
+        var start = System.currentTimeMillis();
+        try {
+            var response = chatClient.prompt()
+                    .system(systemPrompt)
+                    .messages(messages)
+                    .user(symbols)
+                    .call()
+                    .chatResponse();
 
-        var usage = response.getMetadata().getUsage();
-        log.info("tokens - prompt: {}, completion: {}, total: {}",
-                usage.getPromptTokens(),
-                usage.getCompletionTokens(),
-                usage.getTotalTokens());
+            var latencyMs = System.currentTimeMillis() - start;
+            var model = response.getMetadata().getModel();
+            var usage = response.getMetadata().getUsage();
+            log.info("model: {}, latency: {}ms, tokens - prompt: {}, completion: {}, total: {}",
+                    model, latencyMs,
+                    usage.getPromptTokens(),
+                    usage.getCompletionTokens(),
+                    usage.getTotalTokens());
 
-        return response.getResult().getOutput().getText();
+            return GenerationResult.success(
+                    response.getResult().getOutput().getText(), model, latencyMs,
+                    usage.getPromptTokens(), usage.getCompletionTokens(), usage.getTotalTokens()
+            );
+        } catch (Exception e) {
+            var latencyMs = System.currentTimeMillis() - start;
+            log.error("AI 문장 생성 실패: {}", e.getMessage());
+            return GenerationResult.failure(null, latencyMs, e.getMessage());
+        }
     }
 
     public String formatWords(List<WordRequest> words) {

--- a/src/main/java/com/aac/backend/service/WordService.java
+++ b/src/main/java/com/aac/backend/service/WordService.java
@@ -1,21 +1,25 @@
 package com.aac.backend.service;
 
+import com.aac.backend.analytics.AiGenerationLogEvent;
 import com.aac.backend.domain.ConversationMessage;
 import com.aac.backend.domain.ConversationMessageRepository;
 import com.aac.backend.domain.UserRepository;
 import com.aac.backend.global.exception.BusinessException;
 import com.aac.backend.global.exception.ErrorCode;
+import com.aac.backend.infra.GenerationResult;
 import com.aac.backend.infra.WordSentenceGenerator;
 import com.aac.backend.presentation.argumentresolver.LoginUser;
 import com.aac.backend.presentation.dto.request.WordRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +28,7 @@ public class WordService {
 
     private final WordSentenceGenerator wordSentenceGenerator;
     private final ConversationMessageRepository conversationMessageRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
     private final ConversationContextProperties contextProperties;
 
@@ -33,11 +38,18 @@ public class WordService {
                 .map(this::loadContext)
                 .orElse(List.of());
 
-        var sentence = wordSentenceGenerator.generate(words, history);
+        var traceId = UUID.randomUUID().toString();
+        var result = wordSentenceGenerator.generate(words, history);
 
-        loginUser.userId().ifPresent(id -> saveConversationHistory(id, words, sentence));
+        eventPublisher.publishEvent(new AiGenerationLogEvent(traceId, words, history, result));
 
-        return sentence;
+        if (!result.success()) {
+            throw new BusinessException(ErrorCode.AI_GENERATION_FAILED);
+        }
+
+        loginUser.userId().ifPresent(id -> saveConversationHistory(id, words, result.sentence()));
+
+        return result.sentence();
     }
 
     private List<ConversationMessage> loadContext(Long userId) {


### PR DESCRIPTION
## 작업 내용
- `AiGenerationLog` 엔티티 및 `analytics` 패키지 신설
- AI 응답 생성 시 traceId, model, latencyMs, token usage(prompt/completion/total), 성공 여부, 실패 사유 DB 저장
- 비동기 이벤트 기반 저장 (`@Async @EventListener`) — 트레이싱 실패가 메인 트랜잭션에 영향 없음
- `NoResourceFoundException` ERROR 로그 제거 (favicon.ico 등 정적 리소스 404 조용히 처리)

## 변경 이유
AI 응답 품질 및 성능 모니터링을 위한 트레이싱 데이터 수집

## 테스트
- 로컬 H2에서 `/api/words` 호출 후 `ai_generation_logs` 테이블 저장 확인
- 프로덕션 배포 전 MySQL DDL 수동 실행 필요:
  ```sql
  ALTER TABLE ai_generation_logs
      ADD COLUMN prompt_tokens INT,
      ADD COLUMN completion_tokens INT,
      ADD COLUMN total_tokens INT;
  ```

Closes #54