### PR TITLE
feat: AI 응답 리랭크 전략 적용

### DIFF
--- a/src/main/java/com/aac/backend/infra/SentenceReranker.java
+++ b/src/main/java/com/aac/backend/infra/SentenceReranker.java
@@ -1,0 +1,63 @@
+package com.aac.backend.infra;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Component
+public class SentenceReranker {
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 AAC(보완대체의사소통) 문장 선택 전문가입니다.
+            발달장애인이 선택한 기호 목록에 대해 생성된 후보 문장들 중 가장 적절한 것을 고르세요.
+
+            선택 기준:
+            - 모든 기호의 의도가 빠짐없이 자연스럽게 반영되어 있는가
+            - 발달장애인이 실제로 사용하기 좋은 간결하고 자연스러운 구어체인가
+            - 기호에 없는 내용을 임의로 추가하지 않았는가
+
+            선택한 후보의 번호만 숫자로 응답하세요. 다른 텍스트는 포함하지 마세요. (예: 1)
+            """;
+
+    private final ChatClient chatClient;
+
+    public SentenceReranker(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    public String rerank(List<String> candidates, String symbols) {
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+
+        var candidateText = IntStream.range(0, candidates.size())
+                .mapToObj(i -> (i + 1) + ". " + candidates.get(i))
+                .reduce((a, b) -> a + "\n" + b)
+                .orElse("");
+
+        var userMessage = "기호: " + symbols + "\n\n후보:\n" + candidateText;
+
+        try {
+            var response = chatClient.prompt()
+                    .system(SYSTEM_PROMPT)
+                    .user(userMessage)
+                    .call()
+                    .content()
+                    .trim();
+
+            var index = Integer.parseInt(response) - 1;
+            if (index >= 0 && index < candidates.size()) {
+                log.info("리랭크: {}번 선택 - '{}'", index + 1, candidates.get(index));
+                return candidates.get(index);
+            }
+        } catch (Exception e) {
+            log.warn("리랭크 실패, 첫 번째 후보 사용: {}", e.getMessage());
+        }
+
+        return candidates.get(0);
+    }
+}

--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -4,10 +4,11 @@ import com.aac.backend.domain.ConversationMessage;
 import com.aac.backend.presentation.dto.request.WordRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -19,12 +20,18 @@ import java.util.stream.Collectors;
 public class WordSentenceGenerator {
 
     private final ChatClient chatClient;
+    private final SentenceReranker sentenceReranker;
     private final String systemPrompt;
+    private final int candidateCount;
 
     public WordSentenceGenerator(ChatClient chatClient,
-                                 @Value("${prompts.sentence}") String systemPrompt) {
+                                 SentenceReranker sentenceReranker,
+                                 @Value("${prompts.sentence}") String systemPrompt,
+                                 @Value("${generation.candidates:3}") int candidateCount) {
         this.chatClient = chatClient;
+        this.sentenceReranker = sentenceReranker;
         this.systemPrompt = systemPrompt;
+        this.candidateCount = candidateCount;
     }
 
     public GenerationResult generate(List<WordRequest> wordRequests, List<ConversationMessage> history) {
@@ -43,20 +50,27 @@ public class WordSentenceGenerator {
                     .system(systemPrompt)
                     .messages(messages)
                     .user(symbols)
+                    .options(OpenAiChatOptions.builder().N(candidateCount).build())
                     .call()
                     .chatResponse();
 
             var latencyMs = System.currentTimeMillis() - start;
             var model = response.getMetadata().getModel();
             var usage = response.getMetadata().getUsage();
-            log.info("model: {}, latency: {}ms, tokens - prompt: {}, completion: {}, total: {}",
+
+            var candidates = response.getResults().stream()
+                    .map(g -> g.getOutput().getText())
+                    .toList();
+
+            log.info("model: {}, latency: {}ms, tokens - prompt: {}, completion: {}, total: {}, candidates: {}",
                     model, latencyMs,
-                    usage.getPromptTokens(),
-                    usage.getCompletionTokens(),
-                    usage.getTotalTokens());
+                    usage.getPromptTokens(), usage.getCompletionTokens(), usage.getTotalTokens(),
+                    candidates);
+
+            var best = sentenceReranker.rerank(candidates, symbols);
 
             return GenerationResult.success(
-                    response.getResult().getOutput().getText(), model, latencyMs,
+                    best, model, latencyMs,
                     usage.getPromptTokens(), usage.getCompletionTokens(), usage.getTotalTokens()
             );
         } catch (Exception e) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,6 +41,9 @@ oidc:
 prompts:
   sentence: ${prompts.sentence}
 
+generation:
+  candidates: 3
+
 cors:
   allowed-origins:
     - http://localhost:5173


### PR DESCRIPTION
## 작업 내용
- `SentenceReranker` 컴포넌트: LLM 기반 최적 후보 문장 선택
- `WordSentenceGenerator`: OpenAI `n` 파라미터로 N개 후보 생성 후 리랭크 적용
- `generation.candidates` 설정값으로 후보 수 조절 (기본값 3)

## 변경 이유
단일 생성 대비 문장 품질 향상, 리랭크 로직 컴포넌트 분리로 전략 교체 용이

## 테스트
- 로컬 실행 후 로그에서 candidates, 리랭크 선택 결과 확인

Closes #57