### PR TITLE
feat: 대화 컨텍스트 상황 요약 컴포넌트 구현

### DIFF
--- a/src/main/java/com/aac/backend/analytics/AiGenerationLog.java
+++ b/src/main/java/com/aac/backend/analytics/AiGenerationLog.java
@@ -37,10 +37,14 @@ public class AiGenerationLog extends BaseEntity {
 
     private Integer totalTokens;
 
+    @Column(columnDefinition = "TEXT")
+    private String contextSummary;
+
     private AiGenerationLog(String traceId, Integer wordCount, String selectedWords,
                              String model, Long latencyMs, String contextMessages,
                              Boolean success, String failureReason,
-                             Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+                             Integer promptTokens, Integer completionTokens, Integer totalTokens,
+                             String contextSummary) {
         this.traceId = traceId;
         this.wordCount = wordCount;
         this.selectedWords = selectedWords;
@@ -52,18 +56,20 @@ public class AiGenerationLog extends BaseEntity {
         this.promptTokens = promptTokens;
         this.completionTokens = completionTokens;
         this.totalTokens = totalTokens;
+        this.contextSummary = contextSummary;
     }
 
     public static AiGenerationLog success(String traceId, Integer wordCount, String selectedWords,
                                           String model, Long latencyMs, String contextMessages,
-                                          Integer promptTokens, Integer completionTokens, Integer totalTokens) {
+                                          Integer promptTokens, Integer completionTokens, Integer totalTokens,
+                                          String contextSummary) {
         return new AiGenerationLog(traceId, wordCount, selectedWords, model, latencyMs, contextMessages,
-                true, null, promptTokens, completionTokens, totalTokens);
+                true, null, promptTokens, completionTokens, totalTokens, contextSummary);
     }
 
     public static AiGenerationLog failure(String traceId, Integer wordCount, String selectedWords,
                                           String model, Long latencyMs, String contextMessages, String failureReason) {
         return new AiGenerationLog(traceId, wordCount, selectedWords, model, latencyMs, contextMessages,
-                false, failureReason, null, null, null);
+                false, failureReason, null, null, null, null);
     }
 }

--- a/src/main/java/com/aac/backend/analytics/AiGenerationLogEventListener.java
+++ b/src/main/java/com/aac/backend/analytics/AiGenerationLogEventListener.java
@@ -35,7 +35,7 @@ public class AiGenerationLogEventListener {
 
             var generationLog = result.success()
                     ? AiGenerationLog.success(event.traceId(), words.size(), selectedWords, result.model(), result.latencyMs(), contextMessages,
-                            result.promptTokens(), result.completionTokens(), result.totalTokens())
+                            result.promptTokens(), result.completionTokens(), result.totalTokens(), result.contextSummary())
                     : AiGenerationLog.failure(event.traceId(), words.size(), selectedWords, result.model(), result.latencyMs(), contextMessages, result.failureReason());
 
             aiGenerationLogRepository.save(generationLog);

--- a/src/main/java/com/aac/backend/infra/ConversationContextSummarizer.java
+++ b/src/main/java/com/aac/backend/infra/ConversationContextSummarizer.java
@@ -1,0 +1,75 @@
+package com.aac.backend.infra;
+
+import com.aac.backend.domain.ConversationMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConversationContextSummarizer {
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 AAC(보완대체의사소통) 대화 맥락 분석가입니다.
+            이전 대화 기록과 현재 사용자가 선택한 기호를 보고, 현재 기호가 이전 대화와 관련이 있는지 판단하세요.
+
+            판단 기준:
+            - 이전 대화의 장소, 함께 있는 사람, 진행 중인 상황 등이 현재 기호와 연결되면 관련 있음
+            - 완전히 다른 주제로 전환된 경우 관련 없음
+            - 이전에 표현한 욕구 자체는 상황 요약에 포함하지 마세요 (이미 전달된 의사)
+
+            관련 있을 때 요약 형식: "현재 ~하는/~한 상황이다." (한 문장, 명사/장소/상황 위주로)
+            예) 이전: 라면 먹고싶어 → 요약: "현재 라면을 먹고 싶다고 표현한 상황이다." (X)
+                → 요약: "현재 식사 중인 상황이다." (O, 욕구가 아닌 상황으로)
+            예) 이전: 학교 가고싶어 → 현재: 급식 먹고싶어 → "현재 학교에 있는 상황이다."
+
+            다음 JSON 형식으로만 응답하세요:
+            {"related": true, "summary": "현재 학교에 있는 상황이다."}
+            {"related": false, "summary": null}
+            """;
+
+    private final ChatClient chatClient;
+    private final ObjectMapper objectMapper;
+
+    public Optional<String> summarize(List<ConversationMessage> history, String currentSymbols) {
+        if (history == null || history.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var historyText = history.stream()
+                .map(m -> "사용자: " + m.getUserInput() + "\nAI: " + m.getAiResponse())
+                .collect(Collectors.joining("\n"));
+
+        var userMessage = "이전 대화:\n" + historyText + "\n\n현재 기호: " + currentSymbols;
+
+        try {
+            var response = chatClient.prompt()
+                    .system(SYSTEM_PROMPT)
+                    .user(userMessage)
+                    .call()
+                    .content();
+
+            var result = objectMapper.readValue(response, SummaryResult.class);
+
+            if (result.related() && result.summary() != null) {
+                log.info("컨텍스트 요약: '{}'", result.summary());
+                return Optional.of(result.summary());
+            } else {
+                log.info("컨텍스트 무관 — 이전 대화 배제");
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            log.warn("컨텍스트 요약 실패, 배제 처리: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private record SummaryResult(boolean related, String summary) {}
+}

--- a/src/main/java/com/aac/backend/infra/GenerationResult.java
+++ b/src/main/java/com/aac/backend/infra/GenerationResult.java
@@ -8,15 +8,18 @@ public record GenerationResult(
         String failureReason,
         Integer promptTokens,
         Integer completionTokens,
-        Integer totalTokens
+        Integer totalTokens,
+        String contextSummary
 ) {
 
     public static GenerationResult success(String sentence, String model, long latencyMs,
-                                           Integer promptTokens, Integer completionTokens, Integer totalTokens) {
-        return new GenerationResult(sentence, model, latencyMs, true, null, promptTokens, completionTokens, totalTokens);
+                                           Integer promptTokens, Integer completionTokens, Integer totalTokens,
+                                           String contextSummary) {
+        return new GenerationResult(sentence, model, latencyMs, true, null,
+                promptTokens, completionTokens, totalTokens, contextSummary);
     }
 
     public static GenerationResult failure(String model, long latencyMs, String failureReason) {
-        return new GenerationResult(null, model, latencyMs, false, failureReason, null, null, null);
+        return new GenerationResult(null, model, latencyMs, false, failureReason, null, null, null, null);
     }
 }

--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -4,14 +4,10 @@ import com.aac.backend.domain.ConversationMessage;
 import com.aac.backend.presentation.dto.request.WordRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,15 +17,18 @@ public class WordSentenceGenerator {
 
     private final ChatClient chatClient;
     private final SentenceReranker sentenceReranker;
+    private final ConversationContextSummarizer contextSummarizer;
     private final String systemPrompt;
     private final int candidateCount;
 
     public WordSentenceGenerator(ChatClient chatClient,
                                  SentenceReranker sentenceReranker,
+                                 ConversationContextSummarizer contextSummarizer,
                                  @Value("${prompts.sentence}") String systemPrompt,
                                  @Value("${generation.candidates:3}") int candidateCount) {
         this.chatClient = chatClient;
         this.sentenceReranker = sentenceReranker;
+        this.contextSummarizer = contextSummarizer;
         this.systemPrompt = systemPrompt;
         this.candidateCount = candidateCount;
     }
@@ -38,17 +37,12 @@ public class WordSentenceGenerator {
         var symbols = formatWords(wordRequests);
         log.info("symbols: {}", symbols);
 
-        var messages = new ArrayList<Message>();
-        for (ConversationMessage msg : history) {
-            messages.add(new UserMessage(msg.getUserInput()));
-            messages.add(new AssistantMessage(msg.getAiResponse()));
-        }
+        var contextualPrompt = buildSystemPrompt(history, symbols);
 
         var start = System.currentTimeMillis();
         try {
             var response = chatClient.prompt()
-                    .system(systemPrompt)
-                    .messages(messages)
+                    .system(contextualPrompt)
                     .user(symbols)
                     .options(OpenAiChatOptions.builder().N(candidateCount).build())
                     .call()
@@ -78,6 +72,14 @@ public class WordSentenceGenerator {
             log.error("AI 문장 생성 실패: {}", e.getMessage());
             return GenerationResult.failure(null, latencyMs, e.getMessage());
         }
+    }
+
+    private String buildSystemPrompt(List<ConversationMessage> history, String symbols) {
+        var summary = contextSummarizer.summarize(history, symbols);
+        if (summary.isEmpty()) {
+            return systemPrompt;
+        }
+        return systemPrompt + "\n\n현재 상황: " + summary.get() + "\n이 상황을 고려하여 문장을 생성하세요.";
     }
 
     public String formatWords(List<WordRequest> words) {

--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -37,12 +37,12 @@ public class WordSentenceGenerator {
         var symbols = formatWords(wordRequests);
         log.info("symbols: {}", symbols);
 
-        var contextualPrompt = buildSystemPrompt(history, symbols);
+        var summarizedPrompt = buildSystemPrompt(history, symbols);
 
         var start = System.currentTimeMillis();
         try {
             var response = chatClient.prompt()
-                    .system(contextualPrompt)
+                    .system(summarizedPrompt.prompt())
                     .user(symbols)
                     .options(OpenAiChatOptions.builder().N(candidateCount).build())
                     .call()
@@ -65,7 +65,8 @@ public class WordSentenceGenerator {
 
             return GenerationResult.success(
                     best, model, latencyMs,
-                    usage.getPromptTokens(), usage.getCompletionTokens(), usage.getTotalTokens()
+                    usage.getPromptTokens(), usage.getCompletionTokens(), usage.getTotalTokens(),
+                    summarizedPrompt.contextSummary()
             );
         } catch (Exception e) {
             var latencyMs = System.currentTimeMillis() - start;
@@ -74,13 +75,16 @@ public class WordSentenceGenerator {
         }
     }
 
-    private String buildSystemPrompt(List<ConversationMessage> history, String symbols) {
+    private SummarizedPrompt buildSystemPrompt(List<ConversationMessage> history, String symbols) {
         var summary = contextSummarizer.summarize(history, symbols);
         if (summary.isEmpty()) {
-            return systemPrompt;
+            return new SummarizedPrompt(systemPrompt, null);
         }
-        return systemPrompt + "\n\n현재 상황: " + summary.get() + "\n이 상황을 고려하여 문장을 생성하세요.";
+        var prompt = systemPrompt + "\n\n현재 상황: " + summary.get() + "\n이 상황을 고려하여 문장을 생성하세요.";
+        return new SummarizedPrompt(prompt, summary.get());
     }
+
+    private record SummarizedPrompt(String prompt, String contextSummary) {}
 
     public String formatWords(List<WordRequest> words) {
         return words.stream()

--- a/src/test/java/com/aac/backend/infra/SentenceQualityEvalTest.java
+++ b/src/test/java/com/aac/backend/infra/SentenceQualityEvalTest.java
@@ -104,6 +104,19 @@ class SentenceQualityEvalTest {
                 .as("id=%d: %s\n  기호: %s\n  문장: %s",
                         evalCase.id(), evalResult.reason(), symbols, result.sentence())
                 .isTrue();
+
+        if (evalCase.id() == 26) {
+            assertContextNotLeaked(result.sentence(), List.of("물", "라면", "사과"), evalCase.id());
+        }
+    }
+
+    private void assertContextNotLeaked(String sentence, List<String> forbiddenWords, int caseId) {
+        for (var word : forbiddenWords) {
+            assertThat(sentence)
+                    .as("id=%d: 이전 컨텍스트('%s')가 무관한 현재 문장에 포함되어서는 안 됨\n  문장: %s", caseId, word, sentence)
+                    .doesNotContain(word);
+        }
+        log.info("[id={}] 컨텍스트 배제 검증 통과 — 금지어 {} 모두 미포함", caseId, forbiddenWords);
     }
 
     private List<ConversationMessage> buildHistory(List<HistoryEntry> entries) throws Exception {

--- a/src/test/resources/sentence-eval-dataset.json
+++ b/src/test/resources/sentence-eval-dataset.json
@@ -262,5 +262,19 @@
       { "category": "행동", "label": "먹고싶어" }
     ],
     "referenceAnswer": "엄마랑 밥 먹고 싶어."
+  },
+  {
+    "id": 26,
+    "symbolCount": 1,
+    "description": "무관한 컨텍스트 배제 검증: 음식 3턴 이후 무관한 물건(공책) 요청 — 이전 대화가 반영되지 않아야 함",
+    "history": [
+      { "userInput": "[음식] 물, [행동] 먹고싶어", "aiResponse": "나 물 마시고 싶어." },
+      { "userInput": "[음식] 라면, [행동] 먹고싶어", "aiResponse": "나 라면 먹고 싶어." },
+      { "userInput": "[음식] 사과, [행동] 먹고싶어", "aiResponse": "나 사과 먹고 싶어." }
+    ],
+    "words": [
+      { "category": "물건", "label": "공책" }
+    ],
+    "referenceAnswer": "나 공책 필요해."
   }
 ]


### PR DESCRIPTION
## 작업 내용
- `ConversationContextSummarizer`: 이전 대화를 "현재 ~한 상황이다." 형태로 요약
  - 현재 기호와 관련 있으면 요약 반환, 무관하면 컨텍스트 배제
- `WordSentenceGenerator`: 원문 히스토리 메시지 대신 요약 상황을 시스템 프롬프트에 주입
- `GenerationResult` / `AiGenerationLog`: `contextSummary` 필드 추가 — 트레이싱 가능
- 평가 데이터셋 id=26: 무관 컨텍스트 배제 검증 케이스 추가

## 변경 이유
이전 대화 원문 전달 시 욕구 중복 반영 문제 해결, 토큰 절감

## 배포 전 DB 마이그레이션
```sql
ALTER TABLE ai_generation_logs ADD COLUMN context_summary TEXT;
```

Closes #59