### PR TITLE
feat: 기호 수 기반 프롬프트 라우팅 전략 적용

### DIFF
--- a/src/main/java/com/aac/backend/infra/PromptRouter.java
+++ b/src/main/java/com/aac/backend/infra/PromptRouter.java
@@ -1,0 +1,31 @@
+package com.aac.backend.infra;
+
+import com.aac.backend.presentation.dto.request.WordRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class PromptRouter {
+
+    private final String standardPrompt;
+    private final String singleSymbolPrompt;
+
+    public PromptRouter(@Value("${prompts.sentence}") String standardPrompt,
+                        @Value("${prompts.sentence-single}") String singleSymbolPrompt) {
+        this.standardPrompt = standardPrompt;
+        this.singleSymbolPrompt = singleSymbolPrompt;
+    }
+
+    public String route(List<WordRequest> words) {
+        if (words.size() == 1) {
+            log.info("프롬프트 라우팅: single-symbol (기호 1개)");
+            return singleSymbolPrompt;
+        }
+        log.info("프롬프트 라우팅: standard (기호 {}개)", words.size());
+        return standardPrompt;
+    }
+}

--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -18,18 +18,18 @@ public class WordSentenceGenerator {
     private final ChatClient chatClient;
     private final SentenceReranker sentenceReranker;
     private final ConversationContextSummarizer contextSummarizer;
-    private final String systemPrompt;
+    private final PromptRouter promptRouter;
     private final int candidateCount;
 
     public WordSentenceGenerator(ChatClient chatClient,
                                  SentenceReranker sentenceReranker,
                                  ConversationContextSummarizer contextSummarizer,
-                                 @Value("${prompts.sentence}") String systemPrompt,
+                                 PromptRouter promptRouter,
                                  @Value("${generation.candidates:3}") int candidateCount) {
         this.chatClient = chatClient;
         this.sentenceReranker = sentenceReranker;
         this.contextSummarizer = contextSummarizer;
-        this.systemPrompt = systemPrompt;
+        this.promptRouter = promptRouter;
         this.candidateCount = candidateCount;
     }
 
@@ -37,7 +37,7 @@ public class WordSentenceGenerator {
         var symbols = formatWords(wordRequests);
         log.info("symbols: {}", symbols);
 
-        var summarizedPrompt = buildSystemPrompt(history, symbols);
+        var summarizedPrompt = buildSystemPrompt(wordRequests, history, symbols);
 
         var start = System.currentTimeMillis();
         try {
@@ -75,20 +75,21 @@ public class WordSentenceGenerator {
         }
     }
 
-    private SummarizedPrompt buildSystemPrompt(List<ConversationMessage> history, String symbols) {
+    private SummarizedPrompt buildSystemPrompt(List<WordRequest> words, List<ConversationMessage> history, String symbols) {
+        var basePrompt = promptRouter.route(words);
         var summary = contextSummarizer.summarize(history, symbols);
         if (summary.isEmpty()) {
-            return new SummarizedPrompt(systemPrompt, null);
+            return new SummarizedPrompt(basePrompt, null);
         }
-        var prompt = systemPrompt + "\n\n현재 상황: " + summary.get() + "\n이 상황을 고려하여 문장을 생성하세요.";
+        var prompt = basePrompt + "\n\n현재 상황: " + summary.get() + "\n이 상황을 고려하여 문장을 생성하세요.";
         return new SummarizedPrompt(prompt, summary.get());
     }
-
-    private record SummarizedPrompt(String prompt, String contextSummary) {}
 
     public String formatWords(List<WordRequest> words) {
         return words.stream()
                 .map(w -> "[" + w.category() + "] " + w.label())
                 .collect(Collectors.joining(", "));
     }
+
+    private record SummarizedPrompt(String prompt, String contextSummary) {}
 }


### PR DESCRIPTION
## 작업 내용
- `PromptRouter` 컴포넌트: 기호 1개 → `sentence-single` 프롬프트, 2개 이상 → 표준 프롬프트
- `sentence-single` 프롬프트 개선: 어린이 타겟, 카테고리별 기본 의도 가이드 추가
- `WordSentenceGenerator`: `@Value` 직접 주입 대신 `PromptRouter` 사용

## 변경 이유
1개 기호 입력 시 행동 기호 없이 의도 유추가 어려워 전용 프롬프트로 품질 향상

Closes #62