### PR TITLE
feat: 네이버 클로바 보이스 TTS API 추가

### DIFF
--- a/src/main/java/com/aac/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/aac/backend/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "리소스를 찾을 수 없습니다."),
     AI_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI_GENERATION_FAILED", "AI 문장 생성에 실패했습니다."),
+    TTS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TTS_FAILED", "TTS 음성 합성에 실패했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/aac/backend/infra/clovavoice/ClovaVoiceClient.java
+++ b/src/main/java/com/aac/backend/infra/clovavoice/ClovaVoiceClient.java
@@ -1,0 +1,61 @@
+package com.aac.backend.infra.clovavoice;
+
+import com.aac.backend.global.exception.BusinessException;
+import com.aac.backend.global.exception.ErrorCode;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@EnableConfigurationProperties(ClovaVoiceProperties.class)
+public class ClovaVoiceClient {
+
+    private static final String HEADER_API_KEY_ID = "X-NCP-APIGW-API-KEY-ID";
+    private static final String HEADER_API_KEY = "X-NCP-APIGW-API-KEY";
+
+    private static final String SPEAKER = "nhajun";
+    private static final int VOLUME = 0;
+    private static final int SPEED = 5;
+    private static final int PITCH = 0;
+    private static final String FORMAT = "mp3";
+
+    private final ClovaVoiceProperties properties;
+    private final RestClient restClient;
+
+    public ClovaVoiceClient(ClovaVoiceProperties properties, RestClient.Builder restClientBuilder) {
+        this.properties = properties;
+        this.restClient = restClientBuilder.build();
+    }
+
+    public byte[] synthesize(String text) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("speaker", SPEAKER);
+        params.add("text", text);
+        params.add("volume", String.valueOf(VOLUME));
+        params.add("speed", String.valueOf(SPEED));
+        params.add("pitch", String.valueOf(PITCH));
+        params.add("format", FORMAT);
+
+        try {
+            byte[] result = restClient.post()
+                    .uri(properties.url())
+                    .header(HEADER_API_KEY_ID, properties.apiKeyId())
+                    .header(HEADER_API_KEY, properties.apiKey())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(byte[].class);
+            if (result == null) {
+                throw new BusinessException(ErrorCode.TTS_FAILED);
+            }
+            return result;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.TTS_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/aac/backend/infra/clovavoice/ClovaVoiceProperties.java
+++ b/src/main/java/com/aac/backend/infra/clovavoice/ClovaVoiceProperties.java
@@ -1,0 +1,7 @@
+package com.aac.backend.infra.clovavoice;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "clova-voice")
+public record ClovaVoiceProperties(String apiKeyId, String apiKey, String url) {
+}

--- a/src/main/java/com/aac/backend/presentation/TtsController.java
+++ b/src/main/java/com/aac/backend/presentation/TtsController.java
@@ -1,0 +1,35 @@
+package com.aac.backend.presentation;
+
+import com.aac.backend.global.exception.BusinessException;
+import com.aac.backend.global.exception.ErrorCode;
+import com.aac.backend.presentation.argumentresolver.CurrentUser;
+import com.aac.backend.presentation.argumentresolver.LoginUser;
+import com.aac.backend.presentation.dto.request.TtsRequest;
+import com.aac.backend.service.TtsService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tts")
+public class TtsController {
+
+    private final TtsService ttsService;
+
+    @PostMapping
+    public ResponseEntity<byte[]> synthesize(
+            @Valid @RequestBody TtsRequest request,
+            @CurrentUser LoginUser loginUser
+    ) {
+        loginUser.userId().orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+
+        byte[] audio = ttsService.synthesize(request.text());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, "audio/mpeg")
+                .body(audio);
+    }
+}

--- a/src/main/java/com/aac/backend/presentation/dto/request/TtsRequest.java
+++ b/src/main/java/com/aac/backend/presentation/dto/request/TtsRequest.java
@@ -1,0 +1,8 @@
+package com.aac.backend.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TtsRequest(
+        @NotBlank String text
+) {
+}

--- a/src/main/java/com/aac/backend/service/TtsService.java
+++ b/src/main/java/com/aac/backend/service/TtsService.java
@@ -1,0 +1,16 @@
+package com.aac.backend.service;
+
+import com.aac.backend.infra.clovavoice.ClovaVoiceClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TtsService {
+
+    private final ClovaVoiceClient clovaVoiceClient;
+
+    public byte[] synthesize(String text) {
+        return clovaVoiceClient.synthesize(text);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,7 @@ spring:
       - config/db.yml
       - config/prompts.yml
       - config/conversation.yml
+      - config/clova-voice.yml
   ai:
     openai:
       api-key: ${spring.ai.openai.api-key}


### PR DESCRIPTION
## 작업 내용
- 네이버 클로바 보이스를 사용한 TTS API 추가 (`POST /api/tts`)
- 텍스트를 받아 mp3 오디오 바이너리(`byte[]`)로 응답
- speaker, speed 등 파라미터는 서버 상수로 고정 (nhajun, speed=5)
- 로그인한 사용자만 호출 가능

## 변경 이유
AAC 앱에서 생성된 문장을 음성으로 출력하기 위한 TTS 기능 필요

## 테스트
- 로컬에서 클로바 보이스 API 호출 및 mp3 응답 수신 확인

Closes #71