### PR TITLE
feat: AI 생성 출력 토큰 상한 설정

### DIFF
--- a/src/main/java/com/aac/backend/infra/ConversationContextSummarizer.java
+++ b/src/main/java/com/aac/backend/infra/ConversationContextSummarizer.java
@@ -40,13 +40,16 @@ public class ConversationContextSummarizer {
     private final ChatClient chatClient;
     private final ObjectMapper objectMapper;
     private final String summarizerModel;
+    private final int summarizerMaxCompletionTokens;
 
     public ConversationContextSummarizer(ChatClient chatClient,
                                          ObjectMapper objectMapper,
-                                         @Value("${generation.summarizer-model:gpt-4o-mini}") String summarizerModel) {
+                                         @Value("${generation.summarizer-model:gpt-4o-mini}") String summarizerModel,
+                                         @Value("${generation.summarizer-max-completion-tokens:120}") int summarizerMaxCompletionTokens) {
         this.chatClient = chatClient;
         this.objectMapper = objectMapper;
         this.summarizerModel = summarizerModel;
+        this.summarizerMaxCompletionTokens = summarizerMaxCompletionTokens;
     }
 
     public Optional<String> summarize(List<ConversationMessage> history, String currentSymbols) {
@@ -64,7 +67,10 @@ public class ConversationContextSummarizer {
             var response = chatClient.prompt()
                     .system(SYSTEM_PROMPT)
                     .user(userMessage)
-                    .options(OpenAiChatOptions.builder().model(summarizerModel).build())
+                    .options(OpenAiChatOptions.builder()
+                            .model(summarizerModel)
+                            .maxCompletionTokens(summarizerMaxCompletionTokens)
+                            .build())
                     .call()
                     .content();
 

--- a/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
+++ b/src/main/java/com/aac/backend/infra/WordSentenceGenerator.java
@@ -4,6 +4,8 @@ import com.aac.backend.domain.ConversationMessage;
 import com.aac.backend.presentation.dto.request.WordRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -16,13 +18,16 @@ public class WordSentenceGenerator {
     private final ChatClient chatClient;
     private final ConversationContextSummarizer contextSummarizer;
     private final PromptRouter promptRouter;
+    private final int sentenceMaxCompletionTokens;
 
     public WordSentenceGenerator(ChatClient chatClient,
                                  ConversationContextSummarizer contextSummarizer,
-                                 PromptRouter promptRouter) {
+                                 PromptRouter promptRouter,
+                                 @Value("${generation.sentence-max-completion-tokens:64}") int sentenceMaxCompletionTokens) {
         this.chatClient = chatClient;
         this.contextSummarizer = contextSummarizer;
         this.promptRouter = promptRouter;
+        this.sentenceMaxCompletionTokens = sentenceMaxCompletionTokens;
     }
 
     public GenerationResult generate(List<WordRequest> wordRequests, List<ConversationMessage> history) {
@@ -36,6 +41,9 @@ public class WordSentenceGenerator {
             var response = chatClient.prompt()
                     .system(summarizedPrompt.prompt())
                     .user(symbols)
+                    .options(OpenAiChatOptions.builder()
+                            .maxCompletionTokens(sentenceMaxCompletionTokens)
+                            .build())
                     .call()
                     .chatResponse();
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,8 @@ prompts:
 
 generation:
   summarizer-model: gpt-4o-mini
+  sentence-max-completion-tokens: 64
+  summarizer-max-completion-tokens: 120
 
 
 cors:


### PR DESCRIPTION
## 작업 내용
- 문장 생성 OpenAI 호출에 max_completion_tokens 64 적용
- 컨텍스트 요약 OpenAI 호출에 max_completion_tokens 120 적용
- 출력 토큰 상한 설정값을 application 설정으로 분리

## 변경 이유
OpenAI rate limit의 직접적인 병목은 TPM이지만, 모델이 예외적으로 긴 출력을 생성할 경우 토큰 사용량과 비용이 예측보다 증가할 수 있습니다. 문장 생성/요약 출력 길이에 상한을 두어 운영 안전장치를 추가합니다.

## 테스트
- ./gradlew test

Closes #74