### PR TITLE
fix: 프로덕션 compose H2 설정 적용

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,9 +18,17 @@ services:
       - "8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
+      DB_PROD_URL: "jdbc:h2:file:/app/data/aac;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=FALSE"
+      DB_PROD_USERNAME: sa
+      DB_PROD_PASSWORD: ""
+      DB_PROD_DRIVER_CLASS_NAME: org.h2.Driver
+      DB_PROD_DDL_AUTO: update
+      DB_PROD_SHOW_SQL: "false"
     volumes:
+      - h2_data:/app/data
       - ./src/main/resources/config:/app/config:ro
 
 volumes:
+  h2_data:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## 작업 내용
- docker-compose.prod.yml의 WAS 컨테이너에서 prod 프로필의 DB 설정을 H2 파일 DB로 덮어쓰도록 설정했습니다.
- H2 데이터를 유지하기 위해 h2_data Docker volume을 추가했습니다.

## 변경 이유
프로덕션 compose 배포 환경에서 기존 db.prod 설정 대신 H2를 사용하도록 전환하기 위함입니다.

## 테스트
- docker compose -f docker-compose.prod.yml config: passed
- ./gradlew test: failed (로컬 src/main/resources/config 서브모듈 파일이 없어 config/clova-voice.yml import 실패)

## Remaining Risk
- H2 파일 DB는 Docker volume에 유지되지만 운영용 DB로는 MySQL보다 내구성/동시성 리스크가 있습니다.