### PR TITLE
fix: 프로덕션 compose H2 설정 적용

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,9 +18,17 @@ services:
       - "8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
+      DB_PROD_URL: "jdbc:h2:file:/app/data/aac;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=FALSE"
+      DB_PROD_USERNAME: sa
+      DB_PROD_PASSWORD: ""
+      DB_PROD_DRIVER_CLASS_NAME: org.h2.Driver
+      DB_PROD_DDL_AUTO: update
+      DB_PROD_SHOW_SQL: "false"
     volumes:
+      - h2_data:/app/data
       - ./src/main/resources/config:/app/config:ro
 
 volumes:
+  h2_data:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## 작업 내용
- 프로덕션 Docker Compose의 데이터베이스를 파일 기반 H2로 설정
- H2 데이터를 Docker 볼륨에 영속화

## 변경 이유
새 EC2의 Compose 배포에서 외부 DB 없이 백엔드를 실행하기 위해 적용합니다.

## 테스트
- `docker compose -f docker-compose.prod.yml config`: 통과

Closes #77